### PR TITLE
Make playbook inmutable

### DIFF
--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -107,14 +107,6 @@
     chdir: "{{ playbook_dir }}/{{ app_name }}"
     executable: /bin/bash
 
-- name: Capistrano deploy setup
-  hosts: 127.0.0.1
-  connection: local
-  shell: cap development setup
-  args:
-    chdir: "{{ playbook_dir }}/{{ app_name }}"
-    executable: /bin/bash
-
 - name: Capistrano deploy (this may take a few minutes)
   hosts: 127.0.0.1
   connection: local

--- a/roles/capistrano/templates/deploy.rb
+++ b/roles/capistrano/templates/deploy.rb
@@ -68,10 +68,3 @@ task :refresh_sitemap do
     end
   end
 end
-
-
-task :setup do
-  on roles(:app) do
-    execute 'cd /home/deploy && git clone https://github.com/consul/consul.git tmp'
-  end
-end


### PR DESCRIPTION
References
===
**Issue:** https://github.com/consul/installer/issues/12

What
===
Removing a duplicate capistrano action to clone the repo

Why
===
To be able to run the playbook multiple times in a single server

Notes
===
The initial purpose of this action was to clone the repo in a faster way, we can review it later on :relieved: