### PR TITLE
Deploy using temporary installer branch in CONSUL

### DIFF
--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -70,11 +70,11 @@
 
 - name: Copy secrets configuration to shared folder
   become_user: deploy
-  become: true
-  copy:
-    src: /home/{{ deploy_user }}/consul/current/config/secrets.yml.example
+  template:
+    src: "{{ playbook_dir }}/consul/config/secrets.yml.example"
     dest: /home/{{ deploy_user }}/consul/shared/config/secrets.yml
-    remote_src: yes
+    owner: deploy
+    group: wheel
 
 - name: Copy database configuration to shared folder
   become_user: deploy

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -12,6 +12,7 @@
     repo: https://github.com/consul/consul.git
     dest: "{{ playbook_dir }}/consul"
     clone: yes
+    version: installer
   when: consul_repo.stat.exists == False 
 
 - name: Copy deploy.rb (locally)


### PR DESCRIPTION
What
===
- [1] Copy existing `secrets.example.yml`
- [2] Use CONSUL's [installer branch](https://github.com/consul/consul/compare/installer?expand=1)


Why
===
- [1] We forgot to run the playbook one last time in a blank server, and the location of the `secrets.example.yml` was using capistrano's `current` directory, which does not exist at [this point](https://github.com/consul/installer/compare/installer-branch?expand=1#diff-7ce018e7265aba4e90b399630e5ea4b1R74) in the playbook

- [2] The production `secrets` do not include a `secret_token`, this makes unicorn throw an error when starting the application. In CONSUL's installer branch we are using a default secret_token which _fixes_ the problem. Indeed we should generate a random secret token for every installation here is the [issue](https://github.com/consul/installer/issues/21)