### PR TITLE
Set permissions for capistrano logs

### DIFF
--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -116,6 +116,14 @@
     chdir: "{{ playbook_dir }}/{{ app_name }}"
     executable: /bin/bash
 
+- name: Capistrano log permissions
+  hosts: 127.0.0.1
+  connection: local
+  file: 
+    path: "{{ playbook_dir }}/{{ app_name }}/log/capistrano.log"
+    state: file
+    mode: 0774
+
 - name: Create unicorn 
   file:
     path: "/home/deploy/consul/shared/{{ item }}"


### PR DESCRIPTION
What
===
Set permissions for local capistrano log file

Why
===
It was giving an error when running deploys