### PR TITLE
Add SMTP configuration

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -38,6 +38,14 @@ database_password: "deploy"
 database_hostname: "localhost"
 database_port: 5432
 
+#SMTP
+smtp_address:        "smtp.example.com"
+smtp_port:           25
+smtp_domain:         "your_domain.com"
+smtp_user_name:      "username"
+smtp_password:       "password"
+smtp_authentication: "plain"
+
 postgresql_users:
   - name: deploy
     pass: deploy

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -92,14 +92,6 @@
     owner: deploy
     group: wheel
 
-- name: Copy temporary config/environments/production.rb
-  become_user: deploy
-  template:
-    src: "{{ playbook_dir }}/roles/rails/templates/production.rb"
-    dest: /home/deploy/consul/config/environments/production.rb
-    owner: deploy
-    group: wheel
-
 - name: Install gems (this may take a few minutes)
   hosts: 127.0.0.1
   connection: local
@@ -115,6 +107,14 @@
   args:
     chdir: "{{ playbook_dir }}/{{ app_name }}"
     executable: /bin/bash
+
+- name: Copy temporary config/environments/production.rb
+  become_user: deploy
+  template:
+    src: "{{ playbook_dir }}/roles/rails/templates/production.rb"
+    dest: /home/deploy/consul/current/config/environments/production.rb
+    owner: deploy
+    group: wheel
 
 - name: Capistrano log permissions
   hosts: 127.0.0.1

--- a/roles/rails/templates/production.rb
+++ b/roles/rails/templates/production.rb
@@ -66,6 +66,17 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Rails.application.secrets.server_name }
   config.action_mailer.asset_host = "https://#{Rails.application.secrets.server_name}"
 
+  # SMTP configuration to deliver emails
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              '{{ smtp_address }}',
+    port:                 {{ smtp_port }},
+    domain:               '{{ smtp_domain }}',
+    user_name:            '{{ smtp_user_name }}',
+    password:             '{{ smtp_password }}',
+    authentication:       '{{ smtp_authentication }}',
+    enable_starttls_auto: true }
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
References
===
**Issue: https://github.com/consul/installer/issues/7**

What
===
- Adds SMTP configuration to production.rb
- Add placeholder variables for SMTP configuration
- Copy production.rb template to correct capistrano deploy path
