### PR TITLE
Deactivate SSL configuration

### DIFF
--- a/roles/rails/templates/production.rb
+++ b/roles/rails/templates/production.rb
@@ -42,11 +42,11 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :warn
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
Context
===
SSL configuration to redirect traffic to https is not ready yet

What
===
- Deactivate ssl configuration for production environments until it is configured
- Lower production log level to debug until everything is running smoothly 😌