### PR TITLE
Use http instead of https as the default

### DIFF
--- a/consul.yml
+++ b/consul.yml
@@ -14,6 +14,7 @@
     - postgresql
     - ruby
     - rails
+    - ssl
     - unicorn
     - nginx
     - memcached

--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Use http instead of https (for now https://github.com/consul/installer/issues/8)
+  lineinfile:
+    path: /home/{{ deploy_user }}/consul/config/environments/production.rb
+    regexp: 'force_ssl'
+    line: '  config.force_ssl = false'


### PR DESCRIPTION
What
===
Use http instead of https as the default for now

Why
===
Still need to setup a default SSL certificate to make it all work with https
Let's Encrypt seems like the best option https://github.com/consul/installer/issues/8