### PR TITLE
Deactivate queue by default

### DIFF
--- a/consul.yml
+++ b/consul.yml
@@ -16,6 +16,7 @@
     - rails
     - ssl
     - email
+    - queue
     - unicorn
     - nginx
     - memcached

--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Disable queue with DelayedJobs (for now )
+  become_user: deploy
+  template:
+    src: "{{ playbook_dir }}/roles/queue/templates/delayed_job_config.rb"
+    dest: /home/deploy/consul/config/initializers/delayed_job_config.rb
+    owner: deploy
+    group: wheel

--- a/roles/queue/templates/delayed_job_config.rb
+++ b/roles/queue/templates/delayed_job_config.rb
@@ -1,0 +1,1 @@
+Delayed::Worker.delay_jobs = false


### PR DESCRIPTION
Context
===
We use a queue to send emails and run other long processes asynchronously, that would cause a timeout if run synchronously

What
===
Deactivating for now, as it's not necessary for the initial setup 
But should definitely be reactivated[1] before launching to make the user experience more responsive :relieved:

[1] https://github.com/collectiveidea/delayed_job#running-jobs