### PR TITLE
Fix Nokogiri dependecy

### DIFF
--- a/roles/system/tasks/tools.yml
+++ b/roles/system/tasks/tools.yml
@@ -22,3 +22,4 @@
     - nodejs
     - libpq-dev
     - imagemagick
+    - ruby-dev


### PR DESCRIPTION
What
====
Install system library `ruby-dev`

Why
===
We were getting an error when installing the Nokogiri gem

Thanks ❤️ 
===
Thanks to @jesuxgslp for [pointing this out](https://github.com/consul/installer/issues/42#issue-336317190)! 🙏

Thanks to @warringaa for [the fix](https://github.com/consul/installer/issues/42#issuecomment-417646329)! :clap:

And @TheCoffeMaker for [verifying it](https://github.com/consul/installer/issues/42#issuecomment-422480990)! 👍

