### PR TITLE
Fix Precompile Assets task

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -10,5 +10,17 @@
     update_cache: yes
     cache_valid_time: 86400
 
+- name: Add Node repository
+  become: true
+  apt_repository:
+    repo: deb https://deb.nodesource.com/node_6.x bionic main
+    state: present
+
+- name: Add Node key
+  become: yes
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
+
 #- include: hostname.yml
 - include: tools.yml


### PR DESCRIPTION
What
===
Update Nodejs from 4.x to 6.x

Why
===
We were getting an error when when precompiling assets:
`Autoprefixer doesn't support Node v4.2.6. Update it`

Probably due to the [recent gem update in CONSUL in the Autoprefixer gem](https://github.com/consul/consul/pull/2881)

Thanks ❤️
===

Thanks to @TheCoffeMaker [for pointing this out](https://github.com/consul/installer/issues/42#issuecomment-422480990)! :raised_hands: