### PR TITLE
Update README with package version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Root ssh access to the remote server with a public ssh key
 ssh root@remote-server-ip-address
 ```
 
+Updated system package versions
+```
+sudo apt-get update
+```
+
 Python 2 installed in the remote server
 
 ```


### PR DESCRIPTION
### Context

We are now getting an error, at least from Digital Ocean servers, saying that it can't find Python 2 in the default packages when trying to install it with `sudo apt-get -y install python-simplejson`.

```
TASK [Gathering Facts] ********************************************************************************************************
fatal: [206.189.24.183]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 206.189.24.183 closed.\r\n", "module_stdout": "/bin/sh: 1: /usr/bin/python: not found\r\n", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 127}
```

### Objectives
Fix error by updating package versions before trying to install Python 2.
