### PR TITLE
Downgrade to rvm version 1.29.4

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -31,6 +31,7 @@ ruby_version: 2.3.2
 rvm1_user: "{{ deploy_user }}"
 rvm1_rubies: ['ruby-2.3.2']
 rvm1_install_path: "/home/{{ deploy_user }}/.rvm"
+rvm1_rvm_version: '1.29.4'
 
 #Postgresql
 postgresql_version: 9.6


### PR DESCRIPTION
Context
===
There seems to be a [bug](https://github.com/rvm/rvm/issues/4345) in the latest rvm version (1.29.5) which is preventing rvm's signatures from being verified. And thus stopping CONSUL's Ansible script from completing successfully.

The Ansible script works fine using rvm's `master` branch as it has already been [fixed there](https://github.com/rvm/rvm/issues/4345#issuecomment-378521820)

However the script works fine too using the previous stable version 1.29.4

Objectives
===
Downgrades rvm version from 1.29.5 to 1.29.4 to make the Ansible script complete successfully.