### PR TITLE
Disable DelayedJobs for the Capistrano role

### DIFF
--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -26,6 +26,14 @@
     group: wheel
     mode: 0755
 
+- name: Creates shared initializers folder
+  file: 
+    path: /home/{{ deploy_user }}/consul/shared/config/initializers
+    state: directory    
+    owner: deploy
+    group: wheel
+    mode: 0755
+
 - name: Copy secrets configuration to shared folder
   command: cp /home/{{ deploy_user }}/consul/config/secrets.yml /home/{{ deploy_user }}/consul/shared/config/secrets.yml
 
@@ -34,6 +42,9 @@
 
 - name: Copy production environment configuration to shared folder
   command: cp /home/{{ deploy_user }}/consul/config/environments/production.rb /home/{{ deploy_user }}/consul/shared/config/environments/production.rb
+
+- name: Copy delayed jobs configuration to shared folder
+  command: cp /home/{{ deploy_user }}/consul/config/initializers/delayed_job_config.rb /home/{{ deploy_user }}/consul/shared/config/initializers/delayed_job_config.rb
 
 - name: Copy unicorn.rb template for capistrano to shared folder
   become_user: deploy


### PR DESCRIPTION
Context
===
DelayedJobs is a queue system to send emails asynchronously. It was partially implemented and causing some problems where emails were being stored in the queue and not being delivered. 

Objectives
===
Disable DelayedJobs by default after executing the Capistrano role.