### PR TITLE
Disable RVM auto updates

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -32,6 +32,7 @@ rvm1_user: "{{ deploy_user }}"
 rvm1_rubies: ['ruby-2.3.2']
 rvm1_install_path: "/home/{{ deploy_user }}/.rvm"
 rvm1_rvm_version: '1.29.4'
+rvm1_rvm_check_for_updates: false
 
 #Postgresql
 postgresql_version: 9.6


### PR DESCRIPTION
Context
===
When executing the script a second time, RVM was trying to update to a [buggy release](https://github.com/consul/installer/pull/63) making the script not complete successfully.

Objectives
===
Maintain RMV in version 1.29.4 and do not auto update to 1.29.5 in subsequent runs of the script.