### PR TITLE
simplify host configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/site.retry
+*.retry
 /hosts
 /consul

--- a/README.md
+++ b/README.md
@@ -93,14 +93,13 @@ cp hosts.example hosts
 Update your local `hosts` file with the remote server's ip address
     
 ```
-[servers]
 remote-server-ip-address (maintain other default options)
 ```
 
 Run the ansible playbook
     
 ```
-sudo ansible-playbook -v consul.yml -i hosts --extra-vars "target=servers"
+sudo ansible-playbook -v consul.yml -i hosts
 ```
 
 Visit remote-server-ip-address
@@ -132,7 +131,7 @@ Uncomment this line in `consul.yml` and rerun the installer
 Run the ansible playbook
     
 ```
-sudo ansible-playbook -v consul.yml -i hosts --extra-vars "target=servers"
+sudo ansible-playbook -v consul.yml -i hosts
 ```
 
 Download changes from the `capistrano` branch to your fork

--- a/consul.yml
+++ b/consul.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create deploy user
-  hosts: "{{ target }}"
+  hosts: all
   become: yes
   roles:
     - user
 
 - name: Setup CONSUL
-  hosts: "{{ target }}"
+  hosts: all
   remote_user: deploy
   gather_facts: yes
   roles:
@@ -22,4 +22,3 @@
     - memcached
     - timezone
     # - capistrano
-    


### PR DESCRIPTION
No need to specify a group, since the users are most likely going to be dealing with just one server.