### PR TITLE
wait for apt automatic upgrades

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -2,6 +2,10 @@
 - name: gather facts
   setup:
 
+# https://github.com/ansible/ansible/issues/16593#issuecomment-253026793
+- name: Wait for automatic system updates
+  shell: while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 1; done;
+
 - name: Update and upgrade apt packages (this may take a few minutes)
   become: true
   become_method: sudo


### PR DESCRIPTION
Apt can run in the background - commonly for automatic upgrades - which can cause an error when trying to run it in the foreground simultaneously. Add a check for the lock before running `apt` commands.