### PR TITLE
Use variable for the deploy user

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -7,6 +7,8 @@
 
 - name: Set up system
   hosts: all
+  vars:
+    ansible_user: "{{ deploy_user }}"
   roles:
     - system
 

--- a/db.yml
+++ b/db.yml
@@ -1,5 +1,7 @@
 ---
 - name: Set up PostgreSQL
   hosts: all
+  vars:
+    ansible_user: "{{ deploy_user }}"
   roles:
     - postgresql

--- a/group_vars/all
+++ b/group_vars/all
@@ -8,8 +8,8 @@ timezone: Europe/Madrid
 locale: en_US.UTF-8
 
 # General settings
-deploy_dir: /home/deploy/
 deploy_user: deploy
+deploy_dir: "/home/{{ deploy_user }}/"
 deploy_password: test
 deploy_app_name: test
 deploy_server_hostname: 127.0.0.1
@@ -33,8 +33,8 @@ rvm1_rubies: ["ruby-{{ ruby_version }}"]
 
 #Postgresql
 database_name: "consul_production"
-database_user: "deploy"
-database_password: "deploy"
+database_user: "{{ deploy_user }}"
+database_password: "{{ deploy_user }}"
 database_hostname: "localhost"
 database_port: 5432
 

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -6,7 +6,7 @@
   file:
     path: /home/{{ deploy_user }}/consul/shared
     state: directory
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
     mode: 0755
 
@@ -14,7 +14,7 @@
   file:
     path: /home/{{ deploy_user }}/consul/shared/config
     state: directory
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
     mode: 0755
 
@@ -22,7 +22,7 @@
   file:
     path: /home/{{ deploy_user }}/consul/shared/config/environments
     state: directory
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
     mode: 0755
 
@@ -30,7 +30,7 @@
   file:
     path: /home/{{ deploy_user }}/consul/shared/config/initializers
     state: directory
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
     mode: 0755
 
@@ -49,15 +49,15 @@
 - name: Copy unicorn.rb template for capistrano to shared folder
   template:
     src: "{{ playbook_dir }}/roles/capistrano/templates/unicorn.rb"
-    dest: /home/deploy/consul/shared/config/unicorn.rb
-    owner: deploy
+    dest: "/home/{{ deploy_user }}/consul/shared/config/unicorn.rb"
+    owner: "{{ deploy_user }}"
     group: wheel
 
 - name: Create Unicorn folders
   file:
-    path: "/home/deploy/consul/shared/{{ item }}"
+    path: "/home/{{ deploy_user }}/consul/shared/{{ item }}"
     state: directory
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
     mode: 0775
   with_items:
@@ -71,7 +71,7 @@
   template:
     src: "{{ playbook_dir }}/roles/capistrano/templates/consul_vhost.conf"
     dest: /etc/nginx/sites-enabled/default
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
   notify: restart nginx
 

--- a/roles/capistrano/templates/consul_vhost.conf
+++ b/roles/capistrano/templates/consul_vhost.conf
@@ -1,12 +1,12 @@
 upstream app {
-	server unix:/home/deploy/consul/shared/sockets/unicorn.sock;
+	server unix:/home/{{ deploy_user }}/consul/shared/sockets/unicorn.sock;
 }
 
 server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
-	root /home/deploy/consul/current/public;
+	root /home/{{ deploy_user }}/consul/current/public;
 
 	server_name _;
 

--- a/roles/capistrano/templates/unicorn.rb
+++ b/roles/capistrano/templates/unicorn.rb
@@ -1,6 +1,6 @@
 # set path to the application
-app_dir = "/home/deploy/consul/current"
-shared_dir = "/home/deploy/consul/shared"
+app_dir = "/home/{{ deploy_user }}/consul/current"
+shared_dir = "/home/{{ deploy_user }}/consul/shared"
 working_directory app_dir
 
 # Set unicorn options

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -6,6 +6,6 @@
   template:
     src: "{{ playbook_dir }}/roles/nginx/templates/consul_vhost.conf"
     dest: /etc/nginx/sites-enabled/default
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
   notify: restart nginx

--- a/roles/nginx/templates/consul_vhost.conf
+++ b/roles/nginx/templates/consul_vhost.conf
@@ -1,12 +1,12 @@
 upstream app {
-	server unix:/home/deploy/consul/sockets/unicorn.sock;
+	server unix:/home/{{ deploy_user }}/consul/sockets/unicorn.sock;
 }
 
 server {
 	listen 80 default_server;
 	listen [::]:80 default_server;
 
-	root /home/deploy/consul/public;
+	root /home/{{ deploy_user }}/consul/public;
 
 	server_name _;
 

--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Disable queue with DelayedJobs (for now )
   template:
     src: "{{ playbook_dir }}/roles/queue/templates/delayed_job_config.rb"
-    dest: /home/deploy/consul/config/initializers/delayed_job_config.rb
-    owner: deploy
+    dest: "/home/{{ deploy_user}}/consul/config/initializers/delayed_job_config.rb"
+    owner: "{{ deploy_user }}"
     group: wheel

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -14,13 +14,13 @@
 - name: Deploy user permissions
   file:
     path: /home/{{ deploy_user }}/consul
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
     recurse: true
     mode: 0755
 
 - name: Install gems (this may take a few minutes)
-  shell: source /home/deploy/.rvm/scripts/rvm && bundle install
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle install"
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash
@@ -46,12 +46,12 @@
 - name: Copy database configuration
   template:
     src: "{{ playbook_dir }}/roles/rails/templates/database.yml"
-    dest: /home/deploy/consul/config/database.yml
-    owner: deploy
+    dest: "/home/{{ deploy_user}}/consul/config/database.yml"
+    owner: "{{ deploy_user }}"
     group: wheel
 
 - name: Create Database
-  shell: "source /home/deploy/.rvm/scripts/rvm && /home/deploy/.rvm/gems/ruby-2.3.2/bin/rake db:migrate RAILS_ENV=production"
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && /home/{{ deploy_user}}/.rvm/gems/ruby-2.3.2/bin/rake db:migrate RAILS_ENV=production"
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash
@@ -59,13 +59,13 @@
     RAILS_ENV: 'development'
 
 - name: Load configuration seeds
-  shell: source /home/deploy/.rvm/scripts/rvm && bin/rake db:seed RAILS_ENV=production
+  shell: "source /home/{{ deploy_user}}/.rvm/scripts/rvm && bin/rake db:seed RAILS_ENV=production"
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash
 
 - name: Precompile assets
-  shell: source /home/deploy/.rvm/scripts/rvm && bin/rake assets:precompile RAILS_ENV=production
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake assets:precompile RAILS_ENV=production"
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash

--- a/roles/rails/templates/database.yml
+++ b/roles/rails/templates/database.yml
@@ -3,8 +3,8 @@ default: &default
   encoding: unicode
   host: localhost
   pool: 5
-  username: deploy
-  password: deploy
+  username: {{ deploy_user}}
+  password: {{ deploy_user }}
 
 production:
   <<: *default

--- a/roles/system/tasks/locale.yml
+++ b/roles/system/tasks/locale.yml
@@ -2,7 +2,7 @@
   command: /usr/sbin/update-locale LANG={{locale}} LC_ALL={{locale}}
 
 - name: set /etc/localtime to {{ timezone  }}
-  command: /bin/cp /usr/share/zoneinfo/{{ timezone  }} /etc/localtime
+  command: /bin/cp /usr/share/zoneinfo/{{ timezone  }}/etc/localtime
 
 - name: set /etc/timezone to {{ timezone  }}
   template: src=etc/timezone dest=/etc/timezone

--- a/roles/unicorn/tasks/main.yml
+++ b/roles/unicorn/tasks/main.yml
@@ -2,15 +2,15 @@
 - name: Add unicorn.rb
   template:
     src: ../templates/unicorn.rb
-    dest: /home/deploy/consul/config
-    owner: deploy
+    dest: "/home/{{ deploy_user }}/consul/config"
+    owner: "{{ deploy_user }}"
     group: wheel
 
 - name: Add unicorn files and folders
   file:
-    path: "/home/deploy/consul/{{ item }}"
+    path: "/home/{{ deploy_user}}/consul/{{ item }}"
     state: directory
-    owner: deploy
+    owner: "{{ deploy_user }}"
     group: wheel
     mode: 0775
   with_items:
@@ -20,11 +20,11 @@
 
 - name: Check that Unicorn is running
   stat:
-    path: /home/deploy/consul/pids/unicorn.pid
+    path: "/home/{{ deploy_user }}/consul/pids/unicorn.pid"
   register: unicorn_process
 
 - name: Get running unicorn process
-  shell: "cat /home/deploy/consul/pids/unicorn.pid"
+  shell: "cat /home/{{ deploy_user }}/consul/pids/unicorn.pid"
   register: running_process
   when: unicorn_process.stat.exists == True
 
@@ -34,7 +34,7 @@
   when: unicorn_process.stat.exists == True
 
 - name: Start Unicorn
-  shell: "/home/deploy/.rvm/gems/ruby-2.3.2/wrappers/unicorn -c config/unicorn.rb -E production -D"
+  shell: "/home/{{ deploy_user}}/.rvm/gems/ruby-2.3.2/wrappers/unicorn -c config/unicorn.rb -E production -D"
   args:
     chdir: /home/{{ deploy_user }}/consul
     

--- a/roles/unicorn/templates/unicorn.rb
+++ b/roles/unicorn/templates/unicorn.rb
@@ -1,5 +1,5 @@
 # set path to the application
-app_dir = "/home/deploy/consul"
+app_dir = "/home/{{ deploy_user}}/consul"
 working_directory app_dir
 
 # Set unicorn options

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -13,13 +13,13 @@
 
 - name: Create the deploy user
   user:
-    name: deploy
+    name: "{{ deploy_user }}"
     group: wheel
     state: present
     shell: /bin/bash
 
 - name: Install SSH key
   authorized_key:
-    user: deploy
+    user: "{{ deploy_user }}"
     key: "{{ lookup('file', '{{ ssh_public_key_path }}') }}"
   notify: Restart ssh


### PR DESCRIPTION
## References
**PR:** [Add documentation on how to setup without root access](https://github.com/consul/installer/issues/62)

## Context
There was still some code that had a hardcoded value for the deploy user.

## Objectives
Use a variable `deploy_user` instead of a hardcoded `deploy` value.