### PR TITLE
Run system and user roles at the beginning

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -1,17 +1,4 @@
 ---
-- name: Create deploy user
-  hosts: all
-  become: yes
-  roles:
-    - user
-
-- name: Set up system
-  hosts: all
-  vars:
-    ansible_user: "{{ deploy_user }}"
-  roles:
-    - system
-
 - name: Set up CONSUL
   hosts: all
   vars:

--- a/consul.yml
+++ b/consul.yml
@@ -1,3 +1,5 @@
 ---
+- import_playbook: user.yml
+- import_playbook: system.yml
 - import_playbook: db.yml
 - import_playbook: app.yml

--- a/system.yml
+++ b/system.yml
@@ -1,0 +1,6 @@
+- name: Set up system
+  hosts: all
+  vars:
+    ansible_user: "{{ deploy_user }}"
+  roles:
+    - system

--- a/user.yml
+++ b/user.yml
@@ -1,0 +1,5 @@
+- name: Create deploy user
+  hosts: all
+  become: yes
+  roles:
+    - user


### PR DESCRIPTION
## References
**PR:** [Add documentation on how to setup without root access](https://github.com/consul/installer/issues/62)

## Context
Some roles need to be executed first and be used by later roles.

## Objectives
- The `user` role includes the creation of the user that will install all libraries, so the user role should be run first.
- The `system` role includes general system upgrades, they should be run next.
