### PR TITLE
Do not wait for system updates

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -2,10 +2,6 @@
 - name: gather facts
   setup:
 
-# https://github.com/ansible/ansible/issues/16593#issuecomment-253026793
-- name: Wait for automatic system updates
-  shell: while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; do sleep 1; done;
-
 - name: Update and upgrade apt packages (this may take a few minutes)
   become: true
   become_method: sudo


### PR DESCRIPTION
## Context
Sometimes the installer gets stuck waiting for system updates to occur.

## Objectives
Remove the code that is causing this. Let's see if the [initial problem](https://github.com/consul/installer/pull/83) that created the need to add this change comes back.