### PR TITLE
Make SMTP reg exp more robust

### DIFF
--- a/roles/email/tasks/main.yml
+++ b/roles/email/tasks/main.yml
@@ -7,7 +7,7 @@
     - { regexp: 'delivery_method',       line: '  config.action_mailer.delivery_method = :smtp' }
     - { regexp: 'smtp_settings',         line: '  config.action_mailer.smtp_settings = {' }
     - { regexp: 'address:',              line: '    address:              "{{ smtp_address }}",' }
-    - { regexp: 'port:',                 line: '    port:                 "{{ smtp_port }}",' }
+    - { regexp: 'port: ',                line: '    port:                 "{{ smtp_port }}",' }
     - { regexp: 'domain:',               line: '    domain:               "{{ smtp_domain }}",' }
     - { regexp: 'user_name:',            line: '    user_name:            "{{ smtp_user_name }}",' }
     - { regexp: 'password:',             line: '    password:             "{{ smtp_password }}",' }


### PR DESCRIPTION
## References
**Issue** https://github.com/consul/installer/issues/95

## Context
With the addition of Rails 5 we have added more configuration options to `produciton.rb` creating a conflict in the production.rb configuration file.

## Objectives
Fix error when staring Unicorn due to syntax error in`production.rb` SMTP configuration

