### PR TITLE
Make variables environment agnostic

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -8,6 +8,7 @@ timezone: Europe/Madrid
 locale: en_US.UTF-8
 
 # General settings
+env: production
 root_access: true
 deploy_user: deploy
 deploy_dir: "/home/{{ deploy_user }}/"
@@ -33,7 +34,7 @@ rvm1_user: "{{ deploy_user }}"
 rvm1_rubies: ["ruby-{{ ruby_version }}"]
 
 #Postgresql
-database_name: "consul_production"
+database_name: "consul_{{ env }}"
 database_user: "{{ deploy_user }}"
 database_password: "{{ deploy_user }}"
 database_hostname: "localhost"

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -40,8 +40,8 @@
 - name: Copy database configuration to shared folder
   command: cp /home/{{ deploy_user }}/consul/config/database.yml /home/{{ deploy_user }}/consul/shared/config/database.yml
 
-- name: Copy production environment configuration to shared folder
-  command: cp /home/{{ deploy_user }}/consul/config/environments/production.rb /home/{{ deploy_user }}/consul/shared/config/environments/production.rb
+- name: Copy environment configuration to shared folder
+  command: cp /home/{{ deploy_user }}/consul/config/environments/{{ env }}.rb /home/{{ deploy_user }}/consul/shared/config/environments/{{ env }}.rb
 
 - name: Copy delayed jobs configuration to shared folder
   command: cp /home/{{ deploy_user }}/consul/config/initializers/delayed_job_config.rb /home/{{ deploy_user }}/consul/shared/config/initializers/delayed_job_config.rb

--- a/roles/email/tasks/main.yml
+++ b/roles/email/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Use demo SMTP credentials
   lineinfile: 
-    path: /home/{{ deploy_user }}/consul/config/environments/production.rb
+    path: /home/{{ deploy_user }}/consul/config/environments/{{ env }}.rb
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   with_items:

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -55,8 +55,6 @@
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash
-  environment:
-    RAILS_ENV: 'development'
 
 - name: Load configuration seeds
   shell: "source /home/{{ deploy_user}}/.rvm/scripts/rvm && bin/rake db:seed RAILS_ENV={{ env }}"

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -51,7 +51,7 @@
     group: wheel
 
 - name: Create Database
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && /home/{{ deploy_user}}/.rvm/gems/ruby-2.3.2/bin/rake db:migrate RAILS_ENV=production"
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && /home/{{ deploy_user}}/.rvm/gems/ruby-2.3.2/bin/rake db:migrate RAILS_ENV={{ env }}"
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash
@@ -59,13 +59,13 @@
     RAILS_ENV: 'development'
 
 - name: Load configuration seeds
-  shell: "source /home/{{ deploy_user}}/.rvm/scripts/rvm && bin/rake db:seed RAILS_ENV=production"
+  shell: "source /home/{{ deploy_user}}/.rvm/scripts/rvm && bin/rake db:seed RAILS_ENV={{ env }}"
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash
 
 - name: Precompile assets
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake assets:precompile RAILS_ENV=production"
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake assets:precompile RAILS_ENV={{ env }}"
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash

--- a/roles/rails/templates/database.yml
+++ b/roles/rails/templates/database.yml
@@ -6,6 +6,6 @@ default: &default
   username: {{ deploy_user}}
   password: {{ deploy_user }}
 
-production:
+{{ env }}:
   <<: *default
-  database: consul_production
+  database: consul_{{ env }}

--- a/roles/rails/templates/secrets.yml
+++ b/roles/rails/templates/secrets.yml
@@ -1,2 +1,2 @@
-production:
+{{ env }}:
   secret_key_base: {{ rails_secret_key_base }}

--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Use http instead of https (for now https://github.com/consul/installer/issues/8)
   lineinfile:
-    path: /home/{{ deploy_user }}/consul/config/environments/production.rb
+    path: /home/{{ deploy_user }}/consul/config/environments/{{ env }}.rb
     regexp: 'force_ssl'
     line: '  config.force_ssl = false'

--- a/roles/unicorn/tasks/main.yml
+++ b/roles/unicorn/tasks/main.yml
@@ -34,7 +34,7 @@
   when: unicorn_process.stat.exists == True
 
 - name: Start Unicorn
-  shell: "/home/{{ deploy_user}}/.rvm/gems/ruby-2.3.2/wrappers/unicorn -c config/unicorn.rb -E production -D"
+  shell: "/home/{{ deploy_user}}/.rvm/gems/ruby-2.3.2/wrappers/unicorn -c config/unicorn.rb -E {{ env }} -D"
   args:
     chdir: /home/{{ deploy_user }}/consul
     


### PR DESCRIPTION
## Context

With the addition of [continuos integration](https://github.com/consul/installer/pull/97) and an upcoming PR to setup staging environments, it is necessary to prepare the Installer for multiple environments (`production`, `staging` and `test`).

## Objectives

Update variables that where hardcoded for a `production` environment to be dynamically generated using an `environment` variable.