### PR TITLE
Use yaml as default stdout format

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+# Use the YAML callback plugin.
+stdout_callback = yaml


### PR DESCRIPTION
## Context

It is hard to follow what the installer is doing due the output not being formatted.

## Objectives

Format the standard Ansible output in yaml format.

## Visual changes

**Before**
```
TASK [rails : Install gems (this may take a few minutes)] *********************************************************************
changed: [206.189.228.1] => {"changed": true, "cmd": "source /home/deploy/.rvm/scripts/rvm && bundle install", "delta": "0:01:49.362598", "end": "2019-05-10 14:18:32.071122", "rc": 0, "start": "2019-05-10 14:16:42.708524", "stderr": "", "stderr_lines": [], "stdout": "Fetching gem metadata from https://rails-assets.org/..\nFetching gem metadata from https://rubygems.org/...........\nFetching https://github.com/phatworx/devise_security_extension.git\nFetching gem metadata from https://rails-assets.org/..\nFetching rake 12.3.2\nInstalling rake 12.3.2\nFetching concurrent-ruby 1.1.5\nInstalling concurrent-ruby 1.1.5\nFetching i18n 0.9.5\nInstalling i18n 0.9.5\nFetching minitest 5.11.3\nInstalling minitest 5.11.3\nFetching thread_safe 0.3.6\nInstalling thread_safe 0.3.6\nFetching tzinfo 1.2.5\nInstalling tzinfo 1.2.5\nFetching activesupport 5.0.7.2\nInstalling activesupport 5.0.7.2\nFetching builder 3.2.3\nInstalling builder 3.2.3\nFetching erubis 2.7.0\nInstalling erubis 2.7.0\nFetching mini_portile2 2.4.0\nInstalling mini_portile2 2.4.0\nFetching nokogiri 1.10.2\nInstalling nokogiri 1.10.2 with native extensions\nFetching rails-dom-testing 2.0.3\nInstalling rails-dom-testing 2.0.3\nFetching crass 1.0.4\nInstalling crass 1.0.4\nFetching loofah 2.2.3\nInstalling loofah 2.2.3\nFetching rails-html-sanitizer 1.0.4\nInstalling rails-html-sanitizer 1.0.4\nFetching actionview 5.0.7.2\nInstalling actionview 5.0.7.2\nFetching rack 2.0.6\nInstalling rack 2.0.6\nFetching rack-test 0.6.3\nInstalling rack-test 0.6.3
```

**After**
```
TASK [rails : Install gems (this may take a few minutes)] *********************************************************************
changed: [206.189.228.1] => changed=true 
  cmd: source /home/deploy/.rvm/scripts/rvm && bundle install
  delta: '0:00:00.757597'
  end: '2019-05-10 16:31:45.834406'
  rc: 0
  start: '2019-05-10 16:31:45.076809'
  stderr: ''
  stderr_lines: []
  stdout: |-
    Using rake 12.3.2
    Using concurrent-ruby 1.1.5
    Using i18n 0.9.5
    Using minitest 5.11.3
    Using thread_safe 0.3.6
    Using tzinfo 1.2.5
    Using activesupport 5.0.7.2
    Using builder 3.2.3
    Using erubis 2.7.0
    Using mini_portile2 2.4.0
    Using nokogiri 1.10.2
    Using rails-dom-testing 2.0.3
    Using crass 1.0.4
    Using loofah 2.2.3
    Using rails-html-sanitizer 1.0.4
    Using actionview 5.0.7.2
    Using rack 2.0.6
    Using rack-test 0.6.3
    Using actionpack 5.0.7.2
    Using nio4r 2.3.1
    Using websocket-extensions 0.1.3
    Using websocket-driver 0.6.5
    Using actioncable 5.0.7.2
    Using globalid 0.4.2
```