### PR TITLE
Add DelayedJobs configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ You should now see that change at your remote server's ip address
 
 [How to setup email deliveries](https://youtu.be/9W6txGpe4v4)
 
+Screencast update: The Installer now configures a queue to send emails asynchronously. Thus you will not see a 500 error when there is a misconfiguration, as the email is sent asyncronously and the error will be raised in the queue. To see email error logs open the rails console (`cd /home/deploy/consul/ && bin/rails c production`) and search for the last error in the queue `Delayed::Job.last.last_error`)
+
 Update the following file in your production server:
 `/home/deploy/consul/shared/config/secrets.yml`
 

--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -1,5 +1,5 @@
-- name: Disable queue with DelayedJobs (for now )
-  replace:
-    path: "{{ shared_dir }}/config/secrets.yml"
-    regexp: "  delay_jobs: true"
-    replace: "  delay_jobs: false"
+- name: Start DelayedJobs queue
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/delayed_job -n 2 restart"
+  args:
+    executable: /bin/bash
+    chdir: "{{ release_dir }}"

--- a/roles/rails/templates/database.yml
+++ b/roles/rails/templates/database.yml
@@ -8,4 +8,4 @@ default: &default
 
 {{ env }}:
   <<: *default
-  database: consul_{{ env }}
+  database: {{ database_name }}

--- a/roles/specs/tasks/main.yml
+++ b/roles/specs/tasks/main.yml
@@ -45,3 +45,11 @@
         follow_redirects: no
         validate_certs: yes
         status_code: 301
+
+- name: Get running delayed job processes
+  shell: "ps -ef | grep -v grep | grep -w delayed_job | awk '{print $2}'"
+  register: delayed_job_process
+
+- fail:
+    msg: "Delayed Jobs is not running"
+  when: delayed_job_process.stdout == ""


### PR DESCRIPTION
## Context

Sending emails takes a few precious seconds which can slow down the response time for users. To speed things up we can use a queue to send emails asynchronously in the background. 

The queue is also very useful for long running tasks such as sending newsletters to thousands of users or processing signature sheets.

## Objective

Configure queue using [DelayedJobs](https://github.com/collectiveidea/delayed_job).

## Notes

~We should add a cron script to start the DelayedJob queue after a reboot. For now deploying the application will start the queue after a reboot~ (done in  #147 and consul/consul#3859)