### PR TITLE
Add postgresql-contrib to be able to install postgres extensions.

### DIFF
--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -4,6 +4,7 @@
   apt:
     name:
       - postgresql
+      - postgresql-contrib
       - python-psycopg2
 
 - name: Start Postgres


### PR DESCRIPTION
Fixes #104.

Otherwise, the postgres extensions "pg_trgm" and "unaccent" cannot be installed.