### PR TITLE
Make sure Apache web server is not installed/running

### DIFF
--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -30,5 +30,11 @@
     url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
     state: present
 
+- name: Remove apache server
+  become: true
+  apt:
+    name: apache2
+    state: absent
+
 #- include: hostname.yml
 - include: tools.yml


### PR DESCRIPTION
## Context

Many Ubuntu server images have preinstalled Apache2 web server and configured to be running and using port 80.

This will result in an error when trying to install/configure nginx web server.

## Objectives

- Make sure apache is not installed/running before installing ngnix web server to avoid errors.