### PR TITLE
Increase nginx file size limit for uploads to 32M

### DIFF
--- a/roles/nginx/templates/consul_vhost.j2
+++ b/roles/nginx/templates/consul_vhost.j2
@@ -10,6 +10,8 @@ server {
 
   server_name {{ server_hostname }};
 
+  client_max_body_size 32M;
+
   {% if domain is defined or lookup('env', 'CI') %}
 
     listen [::]:443 ssl ipv6only=on;


### PR DESCRIPTION
In the last versions of Consul, it is possible to set the size of image and file uploads to any value in the settings.

However, when using this installer, nginx sets a default limit of 1MB.

This PR sets a value of 32MB.