### PR TITLE
Allow world readable tmp files

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 # Use the YAML callback plugin.
 stdout_callback = yaml
+allow_world_readable_tmpfiles = true


### PR DESCRIPTION
We're getting an error when running the installer with Ansible 2.8.7 on some servers:

```
TASK [postgresql : Create PostgreSQL database] **************************************************************************************************************
fatal: [146.0.40.30]: FAILED! => 
  msg: |-
    Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: changing ownership of '/var/tmp/ansible-tmp-1570730167.47-95324634845843/': Operation not permitted
    chown: changing ownership of '/var/tmp/ansible-tmp-1570730167.47-95324634845843/AnsiballZ_postgresql_db.py': Operation not permitted
    }). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user

```

The ansible documentation says about [becoming an unprivileged user](http://docs.ansible.com/ansible/latest/user_guide/become.html#becoming-an-unprivileged-user):

> Everything is fine if the module file is executed without using become, when the become_user is root, or when the connection to the remote machine is made as root. In these cases the module file is created with permissions that only allow reading by the user and root.
>
> The problem occurs when the become_user is an unprivileged user
> (...)
> 
> If any of the parameters passed to the module are sensitive in nature, then those pieces of data are located in a world readable module file for the duration of the Ansible module execution. Once the module is done executing, Ansible will delete the temporary file. If you trust the client machines then there’s no problem here. If you do not trust the client machines then this is a potential danger.

Since we trust the client machine, there shouldn't be a problem here.