### PR TITLE
Generate secret key base automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,16 +98,10 @@ Create your [fork](https://help.github.com/articles/fork-a-repo/)
 
 Setup locally for your [development environment](https://docs.consulproject.org/docs/english-documentation/introduction/local_installation))
 
-Uncomment this line in `app.yml` and rerun the installer
+Run the capistrano playbook:
 
 ```
-# - capistrano
-```
-
-Run the ansible playbook
-
-```
-sudo ansible-playbook -v consul.yml -i hosts
+sudo ansible-playbook -v capistrano.yml -i hosts
 ```
 
 Download changes from the `capistrano` branch to your fork

--- a/app.yml
+++ b/app.yml
@@ -16,7 +16,6 @@
     - puma
     - memcached
     - timezone
-    # - capistrano
 
 - name: Check system
   hosts: all

--- a/capistrano.yml
+++ b/capistrano.yml
@@ -1,0 +1,8 @@
+---
+- name: Set up capistrano
+  hosts: all
+  become: true
+  vars:
+    ansible_user: "{{ deploy_user }}"
+  roles:
+    - capistrano

--- a/group_vars/all
+++ b/group_vars/all
@@ -3,7 +3,6 @@ app_name: consul
 #domain: your_domain.com
 
 server_hostname: "{{ domain | default(ansible_default_ipv4.address) }}"
-secret_key_base: "change_me"
 
 # Server Timzone + Locale
 timezone: Europe/Madrid

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -16,7 +16,11 @@
     mode: 0755
 
 - name: Copy environment configuration to shared folder
+  become: true
+  become_user: "{{ deploy_user }}"
   command: "cp {{ release_dir }}/config/environments/{{ env }}.rb {{ shared_dir }}/config/environments/{{ env }}.rb"
 
 - name: Copy delayed jobs configuration to shared folder
+  become: true
+  become_user: "{{ deploy_user }}"
   command: "cp {{ release_dir }}/config/initializers/delayed_job_config.rb {{ shared_dir }}/config/initializers/delayed_job_config.rb"

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: Creates shared config folder
-  file:
-    path: "{{ shared_dir }}/config"
-    state: directory
-    owner: "{{ deploy_user }}"
-    group: wheel
-    mode: 0755
-
 - name: Creates shared environment folder
   file:
     path: "{{ shared_dir }}/config/environments"
@@ -22,12 +14,6 @@
     owner: "{{ deploy_user }}"
     group: wheel
     mode: 0755
-
-- name: Copy secrets configuration to shared folder
-  command: "cp {{ release_dir }}/config/secrets.yml {{ shared_dir }}/config/secrets.yml"
-
-- name: Copy database configuration to shared folder
-  command: "cp {{ release_dir }}/config/database.yml {{ shared_dir }}/config/database.yml"
 
 - name: Copy environment configuration to shared folder
   command: "cp {{ release_dir }}/config/environments/{{ env }}.rb {{ shared_dir }}/config/environments/{{ env }}.rb"

--- a/roles/folder_structure/tasks/main.yml
+++ b/roles/folder_structure/tasks/main.yml
@@ -5,19 +5,13 @@
   register: consul_repo
 
 - name: Git clone CONSUL
+  become: true
+  become_user: "{{ deploy_user }}"
   git:
     repo: https://github.com/consul/consul.git
     dest: "{{ consul_dir }}/releases/0-installer"
     clone: yes
   when: consul_repo.stat.exists == False
-
-- name: Deploy user permissions
-  file:
-    path: "{{ consul_dir }}"
-    owner: "{{ deploy_user }}"
-    group: wheel
-    recurse: true
-    mode: 0755
 
 - name: Add symbolic link for current release folder
   file:

--- a/roles/folder_structure/tasks/main.yml
+++ b/roles/folder_structure/tasks/main.yml
@@ -60,6 +60,14 @@
     group: wheel
   with_items: "{{ shared_dirs }}"
 
+- name: Create shared config folder
+  file:
+    path: "{{ shared_dir }}/config"
+    state: directory
+    owner: "{{ deploy_user }}"
+    group: wheel
+    mode: 0755
+
 - name: Create shared public folder
   file:
     path: "{{ shared_dir }}/public"

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -5,11 +5,34 @@
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
-- name: Copy secrets configuration
+- name: Copy secrets configuration to shared folder
   copy:
     src: "{{ release_dir }}/config/secrets.yml.example"
-    dest: "{{ release_dir }}/config/secrets.yml"
+    dest: "{{ shared_dir }}/config/secrets.yml"
+    owner: "{{ deploy_user }}"
+    group: wheel
+    mode: 0755
     remote_src: yes
+    force: no
+
+- name: Copy database configuration to shared folder
+  template:
+    src: "{{ playbook_dir }}/roles/rails/templates/database.yml"
+    dest: "{{ shared_dir }}/config/database.yml"
+    owner: "{{ deploy_user }}"
+    group: wheel
+    force: no
+
+- name: Add symbolic links for secrets and database configuration
+  file:
+    state: "link"
+    src: "{{ shared_dir }}/config/{{ item }}"
+    dest: "{{ release_dir }}/config/{{ item }}"
+    owner: "{{ deploy_user }}"
+    group: wheel
+  with_items:
+    - "secrets.yml"
+    - "database.yml"
 
 - name: Update secret_key_base configuration in secrets.yml
   lineinfile:
@@ -22,13 +45,6 @@
     path: "{{ release_dir }}/config/secrets.yml"
     regexp: 'server_name'
     line: '  server_name: "{{ server_hostname }}"'
-
-- name: Copy database configuration
-  template:
-    src: "{{ playbook_dir }}/roles/rails/templates/database.yml"
-    dest: "{{ release_dir }}/config/database.yml"
-    owner: "{{ deploy_user }}"
-    group: wheel
 
 - name: Create Database
   shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake db:migrate RAILS_ENV={{ env }}"

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -34,17 +34,24 @@
     - "secrets.yml"
     - "database.yml"
 
-- name: Update secret_key_base configuration in secrets.yml
-  lineinfile:
-    path: "{{ release_dir }}/config/secrets.yml"
-    regexp: 'secret_key_base'
-    line: '  secret_key_base: "{{ secret_key_base }}"'
-
 - name: Update host configuration in secrets.yml
   lineinfile:
     path: "{{ release_dir }}/config/secrets.yml"
     regexp: 'server_name'
     line: '  server_name: "{{ server_hostname }}"'
+
+- name: Generate secret key
+  shell: "source {{ home_dir }}/.rvm/scripts/rvm && bin/rake secret"
+  register: secret_key_base
+  args:
+    chdir: "{{ release_dir }}"
+    executable: /bin/bash
+
+- name: Update secret_key_base configuration in secrets.yml
+  replace:
+    path: "{{ shared_dir }}/config/secrets.yml"
+    regexp: '^{{ env }}:\n  secret_key_base: ""'
+    replace: '{{ env }}:\n  secret_key_base: "{{ secret_key_base.stdout }}"'
 
 - name: Create Database
   shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake db:migrate RAILS_ENV={{ env }}"

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 - name: Install gems (this may take a few minutes)
+  become: true
+  become_user: "{{ deploy_user }}"
   shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle install --path {{ shared_dir }}/bundle --without development test"
   args:
     chdir: "{{ release_dir }}"
@@ -41,6 +43,8 @@
     line: '  server_name: "{{ server_hostname }}"'
 
 - name: Generate secret key
+  become: true
+  become_user: "{{ deploy_user }}"
   shell: "source {{ home_dir }}/.rvm/scripts/rvm && bin/rake secret"
   register: secret_key_base
   args:
@@ -54,18 +58,24 @@
     replace: '{{ env }}:\n  secret_key_base: "{{ secret_key_base.stdout }}"'
 
 - name: Create Database
+  become: true
+  become_user: "{{ deploy_user }}"
   shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake db:migrate RAILS_ENV={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
 - name: Load configuration seeds
+  become: true
+  become_user: "{{ deploy_user }}"
   shell: "source /home/{{ deploy_user}}/.rvm/scripts/rvm && bin/rake db:seed RAILS_ENV={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
 - name: Precompile assets
+  become: true
+  become_user: "{{ deploy_user }}"
   shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake assets:precompile RAILS_ENV={{ env }}"
   args:
     chdir: "{{ release_dir }}"

--- a/roles/rails/templates/secrets.yml
+++ b/roles/rails/templates/secrets.yml
@@ -1,2 +1,0 @@
-{{ env }}:
-  secret_key_base: {{ rails_secret_key_base }}


### PR DESCRIPTION
## References

* Closes #21
* Closes #81

## Background

Right now, we're generating a default "change_me" secret key base, and expect users to change it manually. Furthermore, we overwrite this key when we add capistrano.

## Objectives

* Generate a secure secret key base during the installation process and add it to `secrets.yml`
* Simplify installing capistrano, so we don't overwrite the secret key

## Notes

Running the installer a second time will overwrite the generated secret key. This might or might not be the expected behaviour.