### PR TITLE
Use file module to delete file and folder

### DIFF
--- a/roles/folder_structure/tasks/main.yml
+++ b/roles/folder_structure/tasks/main.yml
@@ -29,11 +29,10 @@
     state: directory
   with_items: "{{ shared_dirs }}"
 
-- name: Remove log/.keep
-  shell: "rm {{ release_dir }}/log/.keep"
-
 - name: Remove log folder
-  shell: "rmdir {{ release_dir }}/log"
+  file:
+    path: "{{ release_dir }}/log"
+    state: absent
 
 - name: Link shared folders
   file:


### PR DESCRIPTION
## Objectives

Simplify code and make it more stable.

## Why
With previous code:

- If the file/folder was not present the installer will throw an error and stop the execution.

- If the file/folder was present we will still get an Ansible warning:
```
[WARNING]: Consider using the file module with state=absent rather than running rm.
```