### PR TITLE
Execute role lestencrypt before role nginx

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -5,8 +5,8 @@
   vars:
     ansible_user: "{{ deploy_user }}"
   roles:
-    - nginx
     - letsencrypt
+    - nginx
 
 - name: Set up CONSUL
   hosts: all


### PR DESCRIPTION
## Background
Executing role `nginx` before `letsencrypt` will result in the following error:
```
TASK [nginx : Restart Nginx] ***************************************************
fatal: [localhost]: FAILED! => changed=false 
  msg: |-
    Unable to restart service nginx: Job for nginx.service failed because the control process exited with error code. See "systemctl status nginx.service" and "journalctl -xe" for details.
```
The output of `systemctl status nginx.service` states:
```
nginx[17087]: nginx: [emerg] open() "/etc/letsencrypt/options-ssl-nginx.conf" failed (2: No such file or directory) in /etc/nginx/sites-enabled/default:18
```

## Objectives
Changing the order of execution of the roles fixes the issue