### PR TITLE
Use "present" instead of "installed" as apt state

### DIFF
--- a/galaxy/geerlingguy.memcached/tasks/main.yml
+++ b/galaxy/geerlingguy.memcached/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Install Memcached.
   become: true
-  package: name=memcached state=installed
+  package: name=memcached state=present
   register: memcached_install
 
 # Configure Memcached.


### PR DESCRIPTION
The "installed" state is deprecated and has been removed in some versions of Ansible.