### PR TITLE
Don't require sudo to run the playbook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - pip install ansible
 before_script:
   # Set up host inventory
-  - echo "localhost ansible_connection=local" > hosts
+  - echo "localhost ansible_connection=local ansible_user=root" > hosts
   # Generate dummy SSH key
   - ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
 script: ansible-playbook consul.yml -i hosts

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Updated system package versions
 sudo apt-get update
 ```
 
-Python 2 installed in the remote server
+Python 2.7 installed in the remote server
 
 ```
 sudo apt-get -y install python-simplejson
@@ -52,7 +52,7 @@ sudo apt-get -y install python-simplejson
 
 The following commands must be executed in your local machine
 
-[Install Ansible >= 2.4](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+[Install Ansible >= 2.7](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 
 Get the Ansible Playbook
 

--- a/README.md
+++ b/README.md
@@ -263,9 +263,7 @@ Aside from just using managed databases, you might also look into platform-as-a-
 
 By default the installer assumes you can log in as `root`. The `root` user will only be used once to login and create a `deploy` user. The `deploy` user is the one that will actually install all libraries and is the user that must be used to login to the server to do maintenance tasks.
 
-If you do not have `root` access, you will need your system administrator to grant you: sudo privileges for a `deploy` user in the `wheel` group without password.
-
-Also you will need to change the variable [root access](https://github.com/consul/installer/compare/no_root_user?expand=1#diff-fc7cb0a7b647c6ff35b553a10d616c4bR11) to `false`.
+If you do not have `root` access, you will need your system administrator to grant you sudo privileges for a `deploy` user in the `wheel` group without password. You will also need to change the variable `ansible_user` to `deploy` in your `hosts` file.
 
 ## Using a different user than deploy
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ remote-server-ip-address (maintain other default options)
 Run the ansible playbook
 
 ```
-sudo ansible-playbook -v consul.yml -i hosts
+ansible-playbook -v consul.yml -i hosts
 ```
+
+Note about old versions: if you've already used the installer before version 1.1 was released, you might need to remove your `~/.ansible` folder.
 
 Visit remote-server-ip-address in your browser and you should see CONSUL running!
 
@@ -198,7 +200,7 @@ Next, uncomment the `letsencrypt_email` variable in the [configuration file](htt
 Re-run the installer:
 
 ```
-sudo ansible-playbook -v consul.yml -i hosts
+ansible-playbook -v consul.yml -i hosts
 ```
 
 You should now be able to see the application running at https://your_domain.com in your browser.
@@ -250,7 +252,7 @@ To set up the application by itself:
 1. Run the [`app` playbook](app.yml) instead of the [`consul`](consul.yml) one against a clean server.
 
 ```sh
-sudo ansible-playbook -v app.yml -i hosts
+ansible-playbook -v app.yml -i hosts
 ```
 
 ### Platform-as-a-Service (PaaS)

--- a/group_vars/all
+++ b/group_vars/all
@@ -10,7 +10,6 @@ locale: en_US.UTF-8
 
 # General settings
 env: production
-root_access: true
 deploy_user: deploy
 home_dir: "/home/{{ deploy_user }}"
 deploy_password: test

--- a/hosts.example
+++ b/hosts.example
@@ -1,2 +1,2 @@
 [servers]
-remote-server-ip-address ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ansible_ssh_private_key_file='~/.ssh/id_rsa' ansible_port=22
+remote-server-ip-address ansible_user=root ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ansible_ssh_private_key_file='~/.ssh/id_rsa' ansible_port=22

--- a/user.yml
+++ b/user.yml
@@ -2,4 +2,4 @@
   hosts: all
   become: yes
   roles:
-    - { role: user, when: root_access == true }
+    - { role: user, when: ansible_user == "root" }


### PR DESCRIPTION
## Objectives

* Make it possible for users without sudo privileges on their local machine to run the playbook
* Simplify running the installer with no root access