### PR TITLE
Fix environment for the rake secret task

### DIFF
--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -34,7 +34,7 @@
     line: '  server_name: "{{ server_hostname }}"'
 
 - name: Generate secret key
-  shell: "source {{ home_dir }}/.rvm/scripts/rvm && bin/rake secret"
+  shell: "source {{ home_dir }}/.rvm/scripts/rvm && bin/rake secret RAILS_ENV={{ env }}"
   register: secret_key_base
   args:
     chdir: "{{ release_dir }}"


### PR DESCRIPTION
## References

* Closes #136

## Objectives

Generate the secret running the rake task in the right environment. Otherwise we might get errors because we don't install gems for the development environment.