### PR TITLE
Use symbols instead of strings for SMTP settings

### DIFF
--- a/roles/email/tasks/main.yml
+++ b/roles/email/tasks/main.yml
@@ -4,12 +4,12 @@
     regexp: "{{ item.regexp }}"
     replace: "{{ item.line }}"
   with_items:
-    - { regexp: '# mailer_delivery_method: (.)*', line: 'mailer_delivery_method: "smtp"' }
-    - { regexp: '# smtp_settings:',               line: 'smtp_settings:' }
-    - { regexp: '#   address: (.)*',              line: '  address:              "{{ smtp_address }}"' }
-    - { regexp: '#   port: (.)*',                 line: '  port:                 "{{ smtp_port }}"' }
-    - { regexp: '#   domain: (.)*',               line: '  domain:               "{{ smtp_domain }}"' }
-    - { regexp: '#   user_name: (.)*',            line: '  user_name:            "{{ smtp_user_name }}"' }
-    - { regexp: '#   password: (.)*',             line: '  password:             "{{ smtp_password }}"' }
-    - { regexp: '#   authentication: (.)*',       line: '  authentication:       "{{ smtp_authentication }}"' }
-    - { regexp: '#   enable_starttls_auto: (.)*', line: '  enable_starttls_auto: true' }
+    - { regexp: '# mailer_delivery_method: (.)*',  line: 'mailer_delivery_method: :smtp' }
+    - { regexp: '# smtp_settings:',                line: 'smtp_settings:' }
+    - { regexp: '#   :address: (.)*',              line: '  :address:              "{{ smtp_address }}"' }
+    - { regexp: '#   :port: (.)*',                 line: '  :port:                 {{ smtp_port }}' }
+    - { regexp: '#   :domain: (.)*',               line: '  :domain:               "{{ smtp_domain }}"' }
+    - { regexp: '#   :user_name: (.)*',            line: '  :user_name:            "{{ smtp_user_name }}"' }
+    - { regexp: '#   :password: (.)*',             line: '  :password:             "{{ smtp_password }}"' }
+    - { regexp: '#   :authentication: (.)*',       line: '  :authentication:       "{{ smtp_authentication }}"' }
+    - { regexp: '#   :enable_starttls_auto: (.)*', line: '  :enable_starttls_auto: true' }


### PR DESCRIPTION
## References

* Closes #139
* Depends on consul/consul#3871

## Objectives

Fix a bug which caused `ActionMailer` not to correctly recognize the options in `secrets.yml`.