### PR TITLE
Update 'How to setup Capistrano' screencast

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,7 @@ To restart the server and deploy new code to the server we have to configure Cap
 
 ### Screencast
 
-Note this screencast is not up to date and contains more steps than actually needed; when in doubt, do what we say on this README file.
-
-[How to setup Capistrano](https://youtu.be/SgJzJ-clIrQ)
+[How to setup Capistrano](https://youtu.be/ZCfPz_c_H6g)
 
 Create your [fork](https://help.github.com/articles/fork-a-repo/)
 


### PR DESCRIPTION
## Objectives
Update 'How to setup Capistrano' screencast, cutting out of the screencast the parts that had become obsolete.
- **Deprecated screencast**: https://www.youtube.com/watch?v=SgJzJ-clIrQ&t=1s
- **New screencast**: https://www.youtube.com/watch?v=ZCfPz_c_H6g