### PR TITLE
Generate crontab with whenever

### DIFF
--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -70,3 +70,9 @@
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
+
+- name: Update crontab with whenever
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle exec whenever --update-crontab consul --set environment={{ env }}"
+  args:
+    chdir: "{{ release_dir }}"
+    executable: /bin/bash


### PR DESCRIPTION
## References

* Closes #144

## Background

CONSUL automatically executes whenever when deploying with Capistrano. However, we were not configuring it during the installation.

## Objectives

Generate the crontab during the installation, so the scheduled tasks are executed properly even before configuring capistrano.