### PR TITLE
Specify which bundler version to install

### DIFF
--- a/galaxy/rvm.ruby/tasks/rubies.yml
+++ b/galaxy/rvm.ruby/tasks/rubies.yml
@@ -34,7 +34,7 @@
 - name: Install bundler if not installed
   shell: >
     ls {{ rvm1_install_path }}/wrappers/{{ item.stdout }}
-    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item.stdout }}/gem install bundler ; fi
+    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item.stdout }}/gem install bundler --version 1.17.1 ; fi
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item.stdout }}/bundler'
   with_items: '{{ ruby_patch.results }}'


### PR DESCRIPTION
## References

* Related to consul/consul#3931

## Background

Using the latest bundler we got a deprecation warning when adding Capistrano. This warning might turn into an error in the future:

```
[DEPRECATED] The `--deployment` flag is deprecated because it relies on
being remembered across bundler invocations, which bundler will no
longer do in future versions.
```

## Objectives

Use the same version of Bundler we used to generate our Gemfile.lock.

## Notes

We could also upgrade to bundler 2.x, but since we're using Ruby 2.4, and Ruby 2.6 comes with bundler 1.17, we've decided to keep this version.

This change requires changing a galaxy, which is something we should generally try to avoid. I haven't found a way to do it while keeping the galaxy as it is by default.