### PR TITLE
Reuse database name variable

### DIFF
--- a/roles/rails/templates/database.yml
+++ b/roles/rails/templates/database.yml
@@ -8,4 +8,4 @@ default: &default
 
 {{ env }}:
   <<: *default
-  database: consul_{{ env }}
+  database: {{ database_name }}


### PR DESCRIPTION
## Background

We were configuring the database name in two places, meaning the installer wouldn't work if someone wanted to change the database name and forgot to change the name in both places.

## Objectives

Configure the database name in only one place.