### PR TITLE
Reuse app name variable

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -15,7 +15,7 @@ home_dir: "/home/{{ deploy_user }}"
 deploy_password: test
 deploy_app_name: test
 deploy_server_hostname: 127.0.0.1
-consul_dir: "{{ home_dir }}/consul"
+consul_dir: "{{ home_dir }}/{{ app_name }}"
 shared_dir: "{{ consul_dir }}/shared"
 release_dir: "{{ consul_dir }}/current"
 shared_dirs:
@@ -29,7 +29,7 @@ shared_public_dirs:
 ssh_public_key_path: "~/.ssh/id_rsa.pub"
 
 #Postgresql
-database_name: "consul_{{ env }}"
+database_name: "{{app_name}}_{{ env }}"
 database_user: "{{ deploy_user }}"
 database_password: "{{ deploy_user }}"
 database_hostname: "localhost"

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -72,7 +72,7 @@
     executable: /bin/bash
 
 - name: Update crontab with whenever
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle exec whenever --update-crontab consul --set environment={{ env }}"
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle exec whenever --update-crontab {{ app_name }} --set environment={{ env }}"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash


### PR DESCRIPTION
## References

* Closes #152

## Background

We were assuming the application name is `consul`, and were writing it in several places, meaning if someone wanted a different name, they'd have to change it in all those places.

## Objectives

Configure the appication name in only one place