### PR TITLE
Add experimental Errbit support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - echo "localhost ansible_connection=local ansible_user=root" > hosts
   # Generate dummy SSH key
   - ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
-script: ansible-playbook consul.yml -i hosts --extra-vars "env=${RAILS_ENV}"
+script: ansible-playbook consul.yml -i hosts --extra-vars "env=${RAILS_ENV} domain=localhost"
 jobs:
   include:
     - name: Xenial (production)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,13 @@ install:
   - sudo apt-get update -y
   - sudo apt-get install -y openssh-server
   - pip install ansible
+services: mongodb
 before_script:
   # Set up host inventory
   - echo "localhost ansible_connection=local ansible_user=root" > hosts
   # Generate dummy SSH key
   - ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
-script: ansible-playbook consul.yml -i hosts --extra-vars "env=${RAILS_ENV} domain=localhost"
+script: ansible-playbook consul.yml -i hosts --extra-vars "env=${RAILS_ENV} domain=localhost errbit=True"
 jobs:
   include:
     - name: Xenial (production)

--- a/app.yml
+++ b/app.yml
@@ -32,6 +32,18 @@
     - memcached
     - timezone
 
+- name: Install Errbit
+  hosts: all
+  become: true
+  vars:
+    ansible_user: "{{ deploy_user }}"
+  roles:
+    - role: mongodb
+      when: errbit|bool
+    - role: errbit
+      become_user: "{{ deploy_user }}"
+      when: errbit|bool
+
 - name: Check system
   hosts: all
   become: true

--- a/group_vars/all
+++ b/group_vars/all
@@ -45,3 +45,8 @@ smtp_authentication: "plain"
 
 #LetsEncrypt
 #letsencrypt_email: "your_email@example.com"
+
+# Errbit
+errbit: False
+errbit_dir: "{{ home_dir }}/errbit"
+errbit_domain: "errbit.{{ domain }}"

--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -1,0 +1,132 @@
+---
+- name: Check that errbit repo exists
+  stat:
+    path: "{{ errbit_dir }}"
+  register: errbit_repo
+
+- name: Clone Errbit repository
+  shell: "git clone https://github.com/errbit/errbit.git {{ errbit_dir }}"
+  when: errbit_repo.stat.exists == False
+
+# TODO: Remove when we upgrade to bundler 2.x
+- name: Use bundler 1.x
+  replace:
+    path: "{{ errbit_dir }}/Gemfile.lock"
+    regexp: '   2.1.2'
+    replace: '   1.17.1'
+
+- name: Create log folder
+  file:
+    path: "{{ errbit_dir }}/log"
+    state: directory
+
+- name: Install Errbit dependencies
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle install"
+  args:
+    chdir: "{{ errbit_dir }}"
+    executable: /bin/bash
+
+- name: Create environment file
+  file:
+    path: "{{ errbit_dir }}/.env"
+    state: touch
+
+- name: Update host configuration
+  lineinfile:
+    path: "{{ errbit_dir }}/.env"
+    line: "ERRBIT_HOST={{ errbit_domain }}"
+
+- name: Check whether the secret key is already defined
+  lineinfile:
+    state: absent
+    path: "{{ errbit_dir }}/.env"
+    regexp: "^SECRET_KEY_BASE="
+  check_mode: true
+  changed_when: false
+  register: existing_secret_key_base
+
+- when: not existing_secret_key_base.found
+  block:
+    - name: Generate secret key
+      shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake secret"
+      register: secret_key_base
+      args:
+        chdir: "{{ errbit_dir }}"
+        executable: /bin/bash
+
+    - name: Update secret_key_base configuration
+      lineinfile:
+        path: "{{ errbit_dir }}/.env"
+        line: "SECRET_KEY_BASE={{ secret_key_base.stdout }}"
+
+    - name: Setup Errbit
+      shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/rake errbit:bootstrap"
+      args:
+        chdir: "{{ errbit_dir }}"
+        executable: /bin/bash
+
+    - name: Precompile Errbit assets
+      shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/rake assets:precompile"
+      args:
+        chdir: "{{ errbit_dir }}"
+        executable: /bin/bash
+
+    - name: Start Errbit
+      shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bundle exec puma -C config/puma.default.rb -e {{ env }} -d"
+      args:
+        chdir: "{{ errbit_dir }}"
+        executable: /bin/bash
+
+- name: Create app if it does not exist
+  shell: 'source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rails runner -e {{ env }} "App.create(name: \"{{ domain }}\")"'
+  args:
+    chdir: "{{ errbit_dir }}"
+    executable: /bin/bash
+
+- name: Read app key
+  shell: "mongo --eval \"db.apps.findOne({ name: '{{ domain }}' }).api_key\" --quiet errbit_{{ env }}"
+  register: errbit_api_key
+  args:
+    chdir: "{{ errbit_dir }}"
+    executable: /bin/bash
+
+- name: Add Errbit API key to CONSUL secrets file
+  replace:
+    path: "{{ shared_dir }}/config/secrets.yml"
+    regexp: '^  errbit_project_key:(.+)$'
+    replace: '  errbit_project_key: "{{ errbit_api_key.stdout }}"'
+
+- name: Add Errbit host to CONSUL secrets file
+  replace:
+    path: "{{ shared_dir }}/config/secrets.yml"
+    regexp: '^  errbit_host:(.+)$'
+    replace: '  errbit_host: "https://{{ errbit_domain }}"'
+
+- name: Restart CONSUL
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/rails restart"
+  args:
+    chdir: "{{ release_dir }}"
+    executable: /bin/bash
+
+- name: Generate SSL certificate
+  become: true
+  become_user: root
+  command: "certbot certonly --nginx --noninteractive --agree-tos --expand -d {{ domain }},{{ errbit_domain }}"
+  when: not lookup("env", "CI")
+
+- name: Update nginx configuration
+  become: true
+  become_user: root
+  template:
+    src: "{{ playbook_dir }}/roles/errbit/templates/errbit.example.com"
+    dest: /etc/nginx/sites-enabled/errbit
+    owner: "{{ deploy_user }}"
+    group: wheel
+
+- name: Restart Nginx
+  become: true
+  become_user: root
+  service:
+    name: nginx
+    state: restarted
+    enabled: true

--- a/roles/errbit/templates/errbit.example.com
+++ b/roles/errbit/templates/errbit.example.com
@@ -1,0 +1,35 @@
+server {
+  listen 80;
+  server_name {{ errbit_domain }};
+  rewrite https://$server_name$request_uri? permanent;
+}
+
+server {
+  listen 443 ssl;
+  server_name {{ errbit_domain }};
+  ssl_certificate /etc/letsencrypt/live/{{ server_hostname }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ server_hostname }}/privkey.pem;
+
+  access_log {{ errbit_dir }}/log/access.log;
+  error_log {{ errbit_dir }}/log/error.log;
+
+  root {{ errbit_dir }}/public/;
+  index index.html;
+
+  location / {
+   proxy_pass http://127.0.0.1:8080;
+   proxy_set_header X-Real-IP  $remote_addr;
+   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+   proxy_set_header X-Forwarded-Proto https;
+   proxy_set_header Host $http_host;
+   proxy_redirect off;
+
+   if (-f $request_filename/index.html) {
+    rewrite (.*) $1/index.html break;
+   }
+
+   if (-f $request_filename.html) {
+    rewrite (.*) $1.html break;
+   }
+  }
+}

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- when: domain is defined
+- when: domain is defined and not lookup("env", "CI")
   block:
     - name: Install software-properties-common
       apt:

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Install MongoDB
+  apt:
+    name:
+      - mongodb
+      - mongodb-server

--- a/roles/nginx/templates/consul_vhost.j2
+++ b/roles/nginx/templates/consul_vhost.j2
@@ -12,7 +12,7 @@ server {
 
   client_max_body_size 32M;
 
-  {% if domain is defined or lookup('env', 'CI') %}
+  {% if domain is defined %}
 
     listen [::]:443 ssl ipv6only=on;
     listen 443 ssl;

--- a/roles/specs/tasks/main.yml
+++ b/roles/specs/tasks/main.yml
@@ -15,7 +15,7 @@
         validate_certs: yes
         status_code: 301
 
-- when: domain is not defined and not lookup('env', 'CI')
+- when: domain is not defined
   block:
     - action: uri url=http://127.0.0.1 return_content=yes validate_certs=False
       register: webpage_https
@@ -29,22 +29,6 @@
         url: http://{{ server_hostname }}
         follow_redirects: no
         status_code: 200
-
-- when: lookup('env', 'CI')
-  block:
-    - action: uri url=https://127.0.0.1 return_content=yes validate_certs=False
-      register: webpage_https
-
-    - fail:
-        msg: "service is not happy {{ webpage_https.content }}"
-      when: "'CONSUL' not in webpage_https.content"
-
-    - name: Redirect to https
-      uri:
-        url: http://{{ server_hostname }}
-        follow_redirects: no
-        validate_certs: yes
-        status_code: 301
 
 - name: Get running delayed job processes
   shell: "ps -ef | grep -v grep | grep -w delayed_job | awk '{print $2}'"


### PR DESCRIPTION
## References

* Errbit support in CONSUL was added in consul/consul#3624

## Notes

* The option to install Errbit is still experimental and so it isn't enabled by default
* If your DNS configuration doesn't automatically handle subdomains, you have to add an entry for the `errbit` subdomain
* During the installation process, a password for the Errbit user is generated and shown in the installer's output messages; make sure to write it down or you'll have to run  `RAILS_ENV=production bin/rake errbit:bootstrap` manually to generate it again