### PR TITLE
Update Travis badge to use travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CONSUL Installer [![Build Status](https://travis-ci.org/consul/installer.svg?branch=master)](https://travis-ci.org/consul/installer)
+# CONSUL Installer [![Build Status](https://travis-ci.com/consul/installer.svg?branch=master)](https://travis-ci.com/consul/installer)
 
 [CONSUL](https://github.com/consul/consul) installer for production environments
 


### PR DESCRIPTION
## Background

The domain travis-ci.org will stop working on December 31st, 2020, so we've now using travis-ci.com for continuous integration.

## Objectives

Update the Travis badge so it points to the URL we now use to run our test suite.