### PR TITLE
Fix path to current release folder in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You should now see that change at your remote server's ip address
 
 [How to setup email deliveries](https://youtu.be/9W6txGpe4v4)
 
-Screencast update: The Installer now configures a queue to send emails asynchronously. Thus you will not see a 500 error when there is a misconfiguration, as the email is sent asyncronously and the error will be raised in the queue. To see email error logs open the rails console (`cd /home/deploy/consul/current/ && bin/rails c production`) and search for the last error in the queue `Delayed::Job.last.last_error`)
+Screencast update: The Installer now configures a queue to send emails asynchronously. Thus you will not see a 500 error when there is a misconfiguration, as the email is sent asyncronously and the error will be raised in the queue. To see email error logs open the rails console (`cd /home/deploy/consul/current/ && bin/rails c -e production`) and search for the last error in the queue `Delayed::Job.last.last_error`)
 
 Update the following file in your production server:
 `/home/deploy/consul/shared/config/secrets.yml`

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You should now see that change at your remote server's ip address
 
 [How to setup email deliveries](https://youtu.be/9W6txGpe4v4)
 
-Screencast update: The Installer now configures a queue to send emails asynchronously. Thus you will not see a 500 error when there is a misconfiguration, as the email is sent asyncronously and the error will be raised in the queue. To see email error logs open the rails console (`cd /home/deploy/consul/ && bin/rails c production`) and search for the last error in the queue `Delayed::Job.last.last_error`)
+Screencast update: The Installer now configures a queue to send emails asynchronously. Thus you will not see a 500 error when there is a misconfiguration, as the email is sent asyncronously and the error will be raised in the queue. To see email error logs open the rails console (`cd /home/deploy/consul/current/ && bin/rails c production`) and search for the last error in the queue `Delayed::Job.last.last_error`)
 
 Update the following file in your production server:
 `/home/deploy/consul/shared/config/secrets.yml`


### PR DESCRIPTION
## References

* Closes #158

## Objectives

* Fix a path in the README file which pointed to the wrong folder
* Use the `-e` option in the `rails c` command, since not using it is deprecated in Rails 5.2 (although we still use Rails 5.1)