### PR TITLE
Use Python 3 instead of Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-  - "2.7"
+  - "3.6"
 install:
   - sudo apt-get update -y
   - sudo apt-get install -y openssh-server
-  - pip install ansible
+  - pip3 install ansible
 services: mongodb
 before_script:
   # Set up host inventory

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Updated system package versions
 sudo apt-get update
 ```
 
-Python 2.7 installed in the remote server
+Python 3 installed in the remote server
 
 ## Running the installer
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ sudo apt-get update
 
 Python 2.7 installed in the remote server
 
-```
-sudo apt-get -y install python-simplejson
-```
-
 ## Running the installer
 
 The following commands must be executed in your local machine

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,3 +2,4 @@
 # Use the YAML callback plugin.
 stdout_callback = yaml
 allow_world_readable_tmpfiles = true
+interpreter_python = auto

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -15,7 +15,7 @@
 
     - name: Install python-certbot-nginx
       apt:
-        name: "python-certbot-nginx"
+        name: "python3-certbot-nginx"
 
     - name: Grab Certbot certificate
       command: "sudo certbot --nginx --noninteractive --agree-tos --email {{ letsencrypt_email }} -d {{ domain }}"
@@ -24,9 +24,9 @@
   block:
     - name: Ensure python OpenSSL dependencies are installed
       apt:
-        name: 
-          - python-setuptools
-          - python-pip
+        name:
+          - python3-setuptools
+          - python3-pip
         state: present
 
     - name: Ensure python OpenSSL dependencies are installed

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -5,7 +5,7 @@
     name:
       - postgresql
       - postgresql-contrib
-      - python-psycopg2
+      - python3-psycopg2
 
 - name: Start Postgres
   become: true
@@ -13,8 +13,6 @@
 
 - become: true
   become_user: postgres
-  vars:
-    ansible_python_interpreter: python
   block:
     - name: Create PostgreSQL database
       postgresql_db:


### PR DESCRIPTION
## References

* [Support for Python 2 ended on January the 1st, 2020](https://pythonclock.org/)

## Objectives

* Use a supported Python version to run Ansible
* Use the default Python version in modern distributions

## Notes

* For now we're using Python 3.6 in our CI because it's the oldest supported release and the one Ubuntu 18.04 shipped with.