### PR TITLE
Add Ubuntu 20.04 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
         rails_env: [staging, production]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: 3.6
+        if: ${{ matrix.os != 'ubuntu-20.04' }}
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+        if: ${{ matrix.os == 'ubuntu-20.04' }}
       - name: Update system packages
         run: sudo apt-get update -y
       - name: Install OpenSSH

--- a/roles/system/tasks/main.yml
+++ b/roles/system/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Add Node repository
   become: true
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_6.x {{ distro_codename.stdout }} main"
+    repo: "deb https://deb.nodesource.com/node_10.x {{ distro_codename.stdout }} main"
     state: present
 
 - name: Remove apache server

--- a/roles/user/handlers/main.yml
+++ b/roles/user/handlers/main.yml
@@ -1,2 +1,0 @@
-- name: Restart ssh
-  service: name=sshd state=restarted

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -22,4 +22,3 @@
   authorized_key:
     user: "{{ deploy_user }}"
     key: "{{ lookup('file', '{{ ssh_public_key_path }}') }}"
-  notify: Restart ssh


### PR DESCRIPTION
## References

* Closes #154

## Objectives

Make it possible to install CONSUL on servers running Ubuntu 20.04.

## Notes

We're getting many Ansible warnings in our CI regarding using world-readable permissions for temporary files. They aren't related to using Ubuntu 20.04 but to the fact that the build for this distribution uses a more recent Ansible version. AFAIK they can safely be ignored, as mentioned in pull request #112.