### PR TITLE
Ensure we are using the installed PostgreSQL version

### DIFF
--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Remove pre-installed PostgreSQL versions
+  become: true
+  apt:
+    name: postgresql*
+    purge: true
+    state: absent
+
 - name: Install PostgreSQL
   become: true
   apt:


### PR DESCRIPTION
# References
We have been experiencing some flake specs since we included Ubuntu 18.04 compatibility #156.

Here is a failed Travis build because an intermitent database error: [198291612](https://travis-ci.com/github/consul/installer/builds/198291612),

# Objective 
Travis Ubuntu images have some PostgreSQL pre-installed versions [1]. As we are installing the latest by ourselves from apt repositories, we can safely remove pre-installed versions. 

Previously to this change, to have multiple versions of Postgres was causing some flake specs at some Travis jobs because sometimes the job launched the right PostgresSQL version but others times not. When running any PostgreSQL version lower than 9.4 we get this flake spec because that database version does not have `jsonb` datatype support. 

```
StandardError: An error has occurred, this and all later migrations canceled:
PG::UndefinedObject: ERROR:  type "jsonb" does not exist
```
[1] https://docs.travis-ci.com/user/reference/bionic/#databases-and-services
# Note
Probably Ubuntu images used by installer users wont have pre-installed versions of PostgreSQL but maybe is also desirable to be sure about this for them too.