### PR TITLE
Create deploy user when using a custom ansible_user

### DIFF
--- a/user.yml
+++ b/user.yml
@@ -2,4 +2,4 @@
   hosts: all
   become: yes
   roles:
-    - { role: user, when: ansible_user == "root" }
+    - { role: user, when: ansible_user != "deploy" }


### PR DESCRIPTION
Some server providers like Amazon provide Ubuntu images with a root privileged user named `ubuntu` instead of `root`, also Vagrant Ubuntu boxes provide a user named `vagrant`.

When I run the installer with any ansible_user different than `root`, the deploy user creation step is always ignored, and the installer crashes at following steps.

This will allow creating the `deploy` user for any `ansible_user` we use except when the `ansible_user` is the `deploy` user.