### PR TITLE
Add compatibility with CONSUL 1.3

### DIFF
--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -40,10 +40,16 @@
     chdir: "{{ release_dir }}"
     executable: /bin/bash
 
-- name: Update secret_key_base configuration in secrets.yml
+- name: Update secret_key_base configuration in secrets.yml (CONSUL 1.2 and earlier)
   replace:
     path: "{{ shared_dir }}/config/secrets.yml"
     regexp: '^{{ env }}:\n  secret_key_base: ""'
+    replace: '{{ env }}:\n  secret_key_base: "{{ secret_key_base.stdout }}"'
+
+- name: Update secret_key_base configuration in secrets.yml (CONSUL 1.3+)
+  replace:
+    path: "{{ shared_dir }}/config/secrets.yml"
+    regexp: '^{{ env }}:\n  # secret_key_base: ""'
     replace: '{{ env }}:\n  secret_key_base: "{{ secret_key_base.stdout }}"'
 
 - name: Do not force https connection


### PR DESCRIPTION
## References

* CONSUL changed the `secrets.yml` file in consul/consul#4438

## Background

We're preparing to release CONSUL version 1.3, which added a change to the default secrets.yml file in order to avoid any chances of using an empty secret key base.

## Objectives

Make the installer compatible with both CONSUL 1.2.0 and CONSUL 1.3.0