### PR TITLE
Don't force the bundler version

### DIFF
--- a/galaxy/rvm.ruby/tasks/rubies.yml
+++ b/galaxy/rvm.ruby/tasks/rubies.yml
@@ -34,7 +34,7 @@
 - name: Install bundler if not installed
   shell: >
     ls {{ rvm1_install_path }}/wrappers/{{ item.stdout }}
-    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item.stdout }}/gem install bundler --version 1.17.1 ; fi
+    | if ! grep "^bundler " ; then {{ rvm1_install_path }}/wrappers/{{ item.stdout }}/gem install bundler ; fi
   args:
     creates: '{{ rvm1_install_path }}/wrappers/{{ item.stdout }}/bundler'
   with_items: '{{ ruby_patch.results }}'


### PR DESCRIPTION
## References

* CONSUL uses Ruby 2.6 since consul/consul#4209 
* The installer uses a version of CONSUL using Ruby 2.6 since we merged pull request #149
* We added a hack to the code of one of our dependencies in pull request #148

## Background

Bundler is now automatically installed when using Ruby 2.6, so the rubies task won't install it, and so we don't have to specify the version anymore.

## Objectives

Remove a no longer necesary hack we added to the code of one of our dependencies.