### PR TITLE
Add context to deployment instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,11 @@ cp config/deploy-secrets.yml.example config/deploy-secrets.yml
 Update `deploy-secrets.yml` with your server's info
 
 ```
-deploy_to: "/home/deploy/consul"
-server1: "your_remote_ip_address"
+production:
+  deploy_to: "/home/deploy/consul"
+  ssh_port: "22"
+  server1: "your_remote_ip_address"
+  user: "deploy"
 ```
 
 Update your `repo_url` in `deploy.rb`

--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ Update `deploy-secrets.yml` with your server's info
 ```
 deploy_to: "/home/deploy/consul"
 server1: "your_remote_ip_address"
-db_server: "localhost"
-server_name: "your_remote_ip_address"
 ```
 
 Update your `repo_url` in `deploy.rb`


### PR DESCRIPTION
## References

* Closes #173

## Objectives

Make it easier to undestand how to edit the `config/deploy-secrets.yml` file.