### PR TITLE
Explicitly install shared-mime-info

### DIFF
--- a/roles/system/tasks/tools.yml
+++ b/roles/system/tasks/tools.yml
@@ -23,3 +23,4 @@
       - libpq-dev
       - imagemagick
       - ruby-dev
+      - shared-mime-info


### PR DESCRIPTION
## References

* Continues pull request #149

## Background

The `shared-mime-info` package is required by the version of mimemagic CONSUL now uses. In the end it looks like we won't be able to remove the mimemagic dependency for a while because both paperclip and caxlsx depend on it, so we need to install this package.

While most GNU/Linux distributions install it by default, some production servers might not have it installed.

## Objectives

Make sure the installer runs on systems where the `shared-mime-info` package has not been installed.