### PR TITLE
Serve compressed CSS and JavaScript assets

### DIFF
--- a/roles/nginx/templates/consul_vhost.j2
+++ b/roles/nginx/templates/consul_vhost.j2
@@ -12,6 +12,12 @@ server {
 
   client_max_body_size 32M;
 
+  location ^~ /assets/ {
+    gzip_static on;
+    expires max;
+    add_header Cache-Control public;
+  }
+
   {% if domain is defined %}
 
     listen [::]:443 ssl ipv6only=on;


### PR DESCRIPTION
## References

* We introduced several Nginx templates in commit c01f67ec1

## Background

In commit c01f67ec1 we introduced several nginx templates. Two of them had this configuration, and one of them didn't.

We chose the one which didn't have this configuration for unrelated reasons, and didn't realize this configuration was missing until now.

Rails already generates a gzipped version of our assets when running `rake assets:precompile`, so the Nginx configuration is the only code we need to change to enable this feature.

## Objectives

* Make CONSUL websites load faster

## Notes

In CONSUL version 1.3.0, the size of the uncompressed JavaScript file is 1.63MB, while the gzipped file size is 478KB. Similarly, the size of the uncompressed CSS file is 538KB, while the gzipped file size is 97KB.

So, in all, with this change the size of the homepage decreases from 2.76MB to 1.16MB, meaning a reduction of about 60%.

Since browsers cache CSS and JavaScript assets, this size reduction will only affect new users, users who have disabled their browser's cache, or users who haven't visited the page since the last time the assets changed. Still, new users (particularly the ones with poor internet connections) will surely enjoy a better experience.

## Release notes

In new installations, we've enabled sending compressed CSS and JavaScript files to users by default, resulting in faster page loads. If you haven't already done so, you can enable them in your current CONSUL installation by editing your server's Nginx configuration file (which is probably in a place like `/etc/nginx/sites-enabled/default`) and adding these lines right after the line starting with `  root`:

```
  location ^~ /assets/ {
        gzip_static on;
        expires max;
        add_header Cache-Control public;
  }
```

Then, restart Nginx (on Ubuntu, run `sudo service nginx restart`).