### PR TITLE
Add ansible key to group_vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ timezone: Europe/Madrid
 locale: en_US.UTF-8
 
 # Authorized Hosts
-ssh_public_key_path: "change_me/.ssh/id_rsa.pub"
+ssh_public_key_path: "~/.ssh/id_rsa.pub"
+ansible_ssh_private_key_file: "~/.ssh/id_rsa"
 
 #Postgresql
 database_name: "consul_production"

--- a/group_vars/all
+++ b/group_vars/all
@@ -25,6 +25,7 @@ shared_public_dirs:
   - "ckeditor_assets"
 
 ssh_public_key_path: "~/.ssh/id_rsa.pub"
+ansible_ssh_private_key_file: "~/.ssh/id_rsa"
 
 #Postgresql
 database_name: "{{app_name}}_{{ env }}"

--- a/hosts.example
+++ b/hosts.example
@@ -1,2 +1,2 @@
 [servers]
-remote-server-ip-address ansible_user=root ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ansible_ssh_private_key_file='~/.ssh/id_rsa' ansible_port=22
+remote-server-ip-address ansible_user=root ansible_ssh_extra_args='-o StrictHostKeyChecking=no' ansible_port=22


### PR DESCRIPTION
I ran into the issue of needing to change the SSH key used and had to dig though the open Issues in order to figure out where I was supposed to add the location of my SSH key. At first I thought I was supposed to set the `ansible_ssh_private_key_file` variable in `hosts`, but that did not seem to work - I was still running into the `could not locate file in lookup: ~/.ssh/id_rsa.pub` issue. I finally came across [this issue](https://github.com/consul/installer/issues/161) and learned that I was supposed to edit the variable in `group_vars/all`, which worked. 

(gotta admit, I am not familiar with Ansible, this might have been a non-issue for someone who is very comfortable with Ansible playbooks)

I added a line about this to the README, in case anyone else runs into the same issue. 