### PR TITLE
Fix certbot installation on Ubuntu 20.04

### DIFF
--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -5,13 +5,20 @@
       apt:
         name: software-properties-common
 
+    - name: Check python3-certbot-nginx is available
+      command: apt-cache show python3-certbot-nginx
+      ignore_errors: yes
+      register: certbot_nginx_available
+
     - name: Add Certbot repository
       apt_repository:
         repo: "ppa:certbot/certbot"
+      when: certbot_nginx_available is not succeeded
 
     - name: Update system
       apt:
         update_cache: yes
+      when: certbot_nginx_available is not succeeded
 
     - name: Install python-certbot-nginx
       apt:

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- when: domain is defined and not lookup("env", "CI")
+- when: domain is defined
   block:
     - name: Install software-properties-common
       apt:
@@ -17,8 +17,9 @@
       apt:
         name: "python3-certbot-nginx"
 
-    - name: Grab Certbot certificate
-      command: "sudo certbot --nginx --noninteractive --agree-tos --email {{ letsencrypt_email }} -d {{ domain }}"
+- name: Grab Certbot certificate
+  command: "sudo certbot --nginx --noninteractive --agree-tos --email {{ letsencrypt_email }} -d {{ domain }}"
+  when: domain is defined and not lookup("env", "CI")
 
 - when: lookup('env', 'CI')
   block:


### PR DESCRIPTION
## References

* Closes #183

## Objectives

Make sure the installer runs on Ubuntu 20.04 when a domain is configured and so an SSL certificate will be installed using Certbot.