### PR TITLE
Install CONSUL version 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Setup locally for your [development environment](https://docs.consulproject.org/
 Checkout the latest stable version:
 
 ```
-git checkout origin/1.3.1 -b stable
+git checkout origin/1.4.0 -b stable
 ```
 
 Create your `deploy-secrets.yml`
@@ -205,13 +205,13 @@ Using https instead of http is an important security configuration. Before you b
 
 Once you have that setup we need to configure the Installer to use your domain in the application.
 
-First, uncomment the `domain` variable in the [configuration file](https://github.com/consul/installer/blob/1.3.1/group_vars/all) and update it with your domain name:
+First, uncomment the `domain` variable in the [configuration file](https://github.com/consul/installer/blob/1.4.0/group_vars/all) and update it with your domain name:
 
 ```
 #domain: "your_domain.com"
 ```
 
-Next, uncomment the `letsencrypt_email` variable in the [configuration file](https://github.com/consul/installer/blob/1.3.1/group_vars/all) and update it with a valid email address:
+Next, uncomment the `letsencrypt_email` variable in the [configuration file](https://github.com/consul/installer/blob/1.4.0/group_vars/all) and update it with a valid email address:
 
 ```
 #letsencrypt_email: "your_email@example.com"
@@ -253,7 +253,7 @@ smtp_password:       "password"
 smtp_authentication: "plain"
 ```
 
-There are many more variables available check them out [here]((https://github.com/consul/installer/blob/1.3.1/group_vars/all))
+There are many more variables available check them out [here]((https://github.com/consul/installer/blob/1.4.0/group_vars/all))
 
 ## Other deployment options
 
@@ -283,7 +283,7 @@ If you do not have `root` access, you will need your system administrator to gra
 
 ## Using a different user than deploy
 
-Change the variable [deploy_user](https://github.com/consul/installer/blob/1.3.1/group_vars/all#L13) to the username you would like to use.
+Change the variable [deploy_user](https://github.com/consul/installer/blob/1.4.0/group_vars/all#L13) to the username you would like to use.
 
 ## Ansible Documentation
 

--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -8,12 +8,12 @@
   shell: "git clone https://github.com/errbit/errbit.git {{ errbit_dir }}"
   when: errbit_repo.stat.exists == False
 
-# TODO: Remove when we upgrade to bundler 2.x
-- name: Use bundler 1.x
-  replace:
-    path: "{{ errbit_dir }}/Gemfile.lock"
-    regexp: '   2.*'
-    replace: '   1.17.1'
+- name: Add Ruby 2.7 compatibility
+  template:
+    src: "{{ playbook_dir }}/roles/errbit/templates/UserGemfile"
+    dest: "{{ errbit_dir }}/UserGemfile"
+    owner: "{{ deploy_user }}"
+    group: "{{ deploy_group }}"
 
 - name: Create log folder
   file:

--- a/roles/errbit/templates/UserGemfile
+++ b/roles/errbit/templates/UserGemfile
@@ -1,0 +1,1 @@
+gem "bigdecimal", "~> 1.4.4"

--- a/roles/folder_structure/tasks/main.yml
+++ b/roles/folder_structure/tasks/main.yml
@@ -22,7 +22,7 @@
         state: directory
 
     - name: Create first release
-      shell: "git archive 1.3.1 | /usr/bin/env tar -x -f - -C {{ first_release_dir }}"
+      shell: "git archive 1.4.0 | /usr/bin/env tar -x -f - -C {{ first_release_dir }}"
       args:
         chdir: "{{ consul_dir }}/repo"
 


### PR DESCRIPTION
:warning: Don't merge until we release CONSUL 1.4.0. When we release version 1.4.0, change the `roles/folder_structure/tasks/main.yml` file so it uses the `1.4.0` tag instead of the `master` branch.

## References

* We use a Ruby 2.7 (which includes Bundler 2) since include consul/consul#4662
* The idea to use bigdecimal 1.4.4 comes from errbit/errbit#1508
* Our [test run #95](https://github.com/consul/installer/runs/3843048951) shows the way the installer failed when using Ruby 2.7
* Our [test run #96](https://github.com/consul/installer/actions/runs/1321938559) shows how the installer works fine with Ruby 2.7 after the changes in this pull request

## Objectives

* Install the latest stable version of CONSUL.
* Make Errbit compatible with the version of Ruby included in CONSUL 1.4.0
* Use Bundler 2 in Errbit, just like in CONSUL