### PR TITLE
Drop support for Ubuntu 16.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
         rails_env: [staging, production]
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ It will also create a `deploy` user to install these libraries
 
 A remote server with one of the supported distributions:
 
-- Ubuntu 16.04 x64
 - Ubuntu 18.04 x64
+- Ubuntu 20.04 x64
 
 Access to a remote server via public ssh key without password.
 The default user is `deploy` but you can [use any user](#using-a-different-user-than-deploy) with sudo privileges.


### PR DESCRIPTION
## Objectives

* Stop testing on unmaintained distributions that new CONSUL installations won't/shouldn't even consider