### PR TITLE
Allow configuring the group used by the deploy user

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ If you do not have `root` access, you will need your system administrator to gra
 
 ## Using a different user than deploy
 
-Change the variable [deploy_user](https://github.com/consul/installer/blob/1.3.1/group_vars/all#L12) to the username you would like to use.
+Change the variable [deploy_user](https://github.com/consul/installer/blob/1.3.1/group_vars/all#L13) to the username you would like to use.
 
 ## Ansible Documentation
 

--- a/group_vars/all
+++ b/group_vars/all
@@ -11,6 +11,7 @@ locale: en_US.UTF-8
 # General settings
 env: production
 deploy_user: deploy
+deploy_group: wheel
 home_dir: "/home/{{ deploy_user }}"
 deploy_server_hostname: 127.0.0.1
 consul_dir: "{{ home_dir }}/{{ app_name }}"

--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -121,7 +121,7 @@
     src: "{{ playbook_dir }}/roles/errbit/templates/errbit.example.com"
     dest: /etc/nginx/sites-enabled/errbit
     owner: "{{ deploy_user }}"
-    group: wheel
+    group: "{{ deploy_group }}"
 
 - name: Restart Nginx
   become: true

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -63,7 +63,7 @@
         src: "{{ playbook_dir }}/roles/letsencrypt/templates/options-ssl-nginx.conf"
         dest: /etc/letsencrypt/options-ssl-nginx.conf
         owner: "{{ deploy_user }}"
-        group: wheel
+        group: "{{ deploy_group }}"
 
     - name: Generate /etc/ssl/certs/dhparam.pem (this may take a few minutes)
       command: openssl dhparam -out /etc/letsencrypt/ssl-dhparams.pem 2048

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -9,7 +9,7 @@
     src: "{{ playbook_dir }}/roles/nginx/templates/consul_vhost.j2"
     dest: /etc/nginx/sites-enabled/default
     owner: "{{ deploy_user }}"
-    group: wheel
+    group: "{{ deploy_group }}"
 
 - name: Restart Nginx
   service:

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -1,20 +1,20 @@
 ---
-- name: Make sure we have a 'wheel' group
+- name: Make sure we have a '{{ deploy_group }}' group
   group:
-    name: wheel
+    name: "{{ deploy_group }}"
     state: present
 
-- name: Allow 'wheel' group to have passwordless sudo
+- name: Allow '{{ deploy_group }}' group to have passwordless sudo
   lineinfile:
     dest: /etc/sudoers
     state: present
-    regexp: '^%wheel'
-    line: '%wheel ALL=(ALL) NOPASSWD: ALL'
+    regexp: '^%{{ deploy_group }}'
+    line: '%{{ deploy_group }} ALL=(ALL) NOPASSWD: ALL'
 
 - name: Create the deploy user
   user:
     name: "{{ deploy_user }}"
-    group: wheel
+    group: "{{ deploy_group }}"
     state: present
     shell: /bin/bash
 

--- a/user.yml
+++ b/user.yml
@@ -2,4 +2,4 @@
   hosts: all
   become: yes
   roles:
-    - { role: user, when: ansible_user != "deploy" }
+    - { role: user, when: ansible_user != deploy_user }


### PR DESCRIPTION
## References

* Makes it easier to do changes related to issue #141
* A typo in the `user.yml` was added in pull request #167

## Objectives

* Make it easier to change the group used by the deploy user
* Fix a typo in a condition which caused it not to be correctly evaluated when the deploy user isn't the default one