### PR TITLE
Add support for Debian Buster and Debian Bullseye

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,0 +1,30 @@
+name: debian
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ["debian:buster", "debian:bullseye"]
+        rails_env: [staging, production]
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update system packages
+        run: apt-get update -y
+      - name: Install needed packages
+        run: apt-get install -y lsb-release sudo python3-pip openssh-server
+      - name: Install Ansible
+        run: pip3 install ansible
+      - name: Create hosts file
+        run: echo "localhost ansible_connection=local ansible_user=root" > hosts
+      - name: Generate dummy SSH key
+        run: mkdir ~/.ssh && ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+      - name: Run CONSUL installer
+        run: ansible-playbook consul.yml -i hosts --extra-vars "env=${{ matrix.rails_env }} domain=localhost errbit=False"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,4 +1,4 @@
-name: tests
+name: ubuntu
 on:
   push:
     branches:
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  tests:
+  ubuntu:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A remote server with one of the supported distributions:
 
 - Ubuntu 18.04 x64
 - Ubuntu 20.04 x64
+- Debian Buster x64
+- Debian Bullseye x64
 
 Access to a remote server via public ssh key without password.
 The default user is `deploy` but you can [use any user](#using-a-different-user-than-deploy) with sudo privileges.

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -9,7 +9,10 @@
 
 - name: Start Postgres
   become: true
-  command: systemctl start postgresql
+  service:
+    name: postgresql
+    state: started
+    enabled: true
 
 - become: true
   become_user: postgres

--- a/roles/system/tasks/tools.yml
+++ b/roles/system/tasks/tools.yml
@@ -5,6 +5,7 @@
     update_cache: true
     name:
       - build-essential
+      - cron
       - tmux
       - vim
       - htop


### PR DESCRIPTION
## References

* Debian is one of the systems mentioned in issue #16

## Objectives

* Increase the number of systems where the installer can be run

## Notes

We aren't enabling Errbit for Debian because Debian [no longer includes MongoDB](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=947743).