### PR TITLE
Make sure Nginx has write access to the puma socket 

### DIFF
--- a/roles/puma/tasks/main.yml
+++ b/roles/puma/tasks/main.yml
@@ -27,3 +27,9 @@
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash
+
+- name: Make sure Nginx has write access to the puma socket
+  shell: "chmod o+w tmp/sockets/*"
+  args:
+    chdir: "{{ release_dir }}"
+    executable: /bin/bash


### PR DESCRIPTION
## References

* The failing tests when this code isn't used can be seen in our [test run #117](https://github.com/consul/installer/actions/runs/1619896844)

## Objectives

Avoid a `connect() to puma.sock failed (13: Permission denied) while connecting to upstream` error in the final steps of the installer when running the tests with Github Actions.

## Notes

The master branch correctly run the tests a month ago, but not anymore, so maybe something has changed in the Ubuntu images provided by Github Actions.

I haven't been able to reproduce this issue on production; the added code is probably redundant in this scenario.