### PR TITLE
Remove code adding Ruby 2.7 compatibility to Errbit

### DIFF
--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -8,13 +8,6 @@
   shell: "git clone https://github.com/errbit/errbit.git {{ errbit_dir }}"
   when: errbit_repo.stat.exists == False
 
-- name: Add Ruby 2.7 compatibility
-  template:
-    src: "{{ playbook_dir }}/roles/errbit/templates/UserGemfile"
-    dest: "{{ errbit_dir }}/UserGemfile"
-    owner: "{{ deploy_user }}"
-    group: "{{ deploy_group }}"
-
 - name: Create log folder
   file:
     path: "{{ errbit_dir }}/log"

--- a/roles/errbit/templates/UserGemfile
+++ b/roles/errbit/templates/UserGemfile
@@ -1,1 +1,0 @@
-gem "bigdecimal", "~> 1.4.4"


### PR DESCRIPTION
## References

* The code adding Ruby 2.7 to Errbit was added in pull request #185
* Errbit added support for Ruby 2.7 in https://github.com/errbit/errbit/pull/1508