### PR TITLE
Use systemd to start Errbit

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -55,3 +55,6 @@ rvm1_gpg_key_servers:
 errbit: False
 errbit_dir: "{{ home_dir }}/errbit"
 errbit_domain: "errbit.{{ domain }}"
+errbit_service: "{{ app_name }}_errbit"
+errbit_user: "{{ deploy_user }}"
+errbit_group: "{{ deploy_group }}"

--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -64,11 +64,21 @@
         chdir: "{{ errbit_dir }}"
         executable: /bin/bash
 
-    - name: Start Errbit
-      shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bundle exec puma -C config/puma.default.rb -e {{ env }} -d"
-      args:
-        chdir: "{{ errbit_dir }}"
-        executable: /bin/bash
+- name: Copy Errbit service file to the systemd folder
+  become: true
+  become_user: root
+  template:
+    src: "{{ playbook_dir }}/roles/errbit/templates/errbit.service"
+    dest: "/etc/systemd/system/{{ errbit_service }}.service"
+
+- name: Start Errbit
+  become: true
+  become_user: root
+  systemd:
+    name: "{{ errbit_service }}"
+    daemon_reload: yes
+    state: started
+    enabled: true
 
 - name: Create app if it does not exist
   shell: 'source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rails runner -e {{ env }} "App.create(name: \"{{ domain }}\")"'

--- a/roles/errbit/templates/errbit.service
+++ b/roles/errbit/templates/errbit.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Errbit - Error tracking application for {{ app_name }}
+Requires=mongodb.service
+After=mongodb.service network.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ errbit_dir }}
+Environment=RAILS_ENV={{ env }}
+ExecStart=/bin/bash -lc 'source {{ home_dir }}/.rvm/scripts/rvm && bundle exec puma -C {{ errbit_dir }}/config/puma.default.rb -e {{ env }}'
+Restart=always
+User={{ errbit_user }}
+Group={{ errbit_group }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## References

* Errbit updated Puma in errbit/errbit#1520
* Puma removed support for the `--daemon` option in Puma 5.0.0 and now requires using systemd or similar

## Objectives

* Make sure it's possible to run Errbit with the installer

## Notes

Our errbit service file is based on the [Puma documentation to configure systemd](https://github.com/puma/puma/blob/21e9a4a65b3/docs/systemd.md). We're also adding a dependency on Mongodb and making sure the process runs as the user with permissions to run Errbit. 