### PR TITLE
Fix mini_racer compilation when installing Errbit

### DIFF
--- a/roles/errbit/tasks/main.yml
+++ b/roles/errbit/tasks/main.yml
@@ -13,6 +13,32 @@
     path: "{{ errbit_dir }}/log"
     state: directory
 
+- name: Get libv8-node version dependency
+  shell: "cat Gemfile.lock | grep 'libv8-node (' | head -n 1 | sed 's/.*(\\(.*\\))/\\1/'"
+  register: libv8_version
+  args:
+    chdir: "{{ errbit_dir }}"
+    executable: /bin/bash
+
+- name: Install libv8-node for the right platform
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && gem install libv8-node --version '{{ libv8_version.stdout }}' --platform x86_64-linux-libc"
+  args:
+    chdir: "{{ errbit_dir }}"
+    executable: /bin/bash
+
+- name: Get mini_racer version dependency
+  shell: "cat Gemfile.lock | grep 'mini_racer (' | sed 's/.*(\\(.*\\))/\\1/'"
+  register: mini_racer_version
+  args:
+    chdir: "{{ errbit_dir }}"
+    executable: /bin/bash
+
+- name: Install the mini_racer gem
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && gem install mini_racer --version '{{ mini_racer_version.stdout }}'"
+  args:
+    chdir: "{{ errbit_dir }}"
+    executable: /bin/bash
+
 - name: Install Errbit dependencies
   shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle install"
   args:


### PR DESCRIPTION
## References

* The solution was suggested in a [comment in the mini_racer issue 243](https://github.com/rubyjs/mini_racer/issues/243#issuecomment-1076909827)
* It looks like this issue will be solved when rubygems/rubygems#4488 is merged

## Background

Errbit has recently updated its mini_racer dependency to version 0.6.2, which apparently can't be installed on Ubuntu with our current Bundler settings.