### PR TITLE
Install CONSUL version 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Setup locally for your [development environment](https://docs.consulproject.org/
 Checkout the latest stable version:
 
 ```
-git checkout origin/1.4.1 -b stable
+git checkout origin/1.5.0 -b stable
 ```
 
 Create your `deploy-secrets.yml`
@@ -207,13 +207,13 @@ Using https instead of http is an important security configuration. Before you b
 
 Once you have that setup we need to configure the Installer to use your domain in the application.
 
-First, uncomment the `domain` variable in the [configuration file](https://github.com/consul/installer/blob/1.4.1/group_vars/all) and update it with your domain name:
+First, uncomment the `domain` variable in the [configuration file](https://github.com/consul/installer/blob/1.5.0/group_vars/all) and update it with your domain name:
 
 ```
 #domain: "your_domain.com"
 ```
 
-Next, uncomment the `letsencrypt_email` variable in the [configuration file](https://github.com/consul/installer/blob/1.4.1/group_vars/all) and update it with a valid email address:
+Next, uncomment the `letsencrypt_email` variable in the [configuration file](https://github.com/consul/installer/blob/1.5.0/group_vars/all) and update it with a valid email address:
 
 ```
 #letsencrypt_email: "your_email@example.com"
@@ -260,7 +260,7 @@ If you are on Ubuntu and would like to use its default `sudo` group instead of `
 deploy_group: sudo
 ```
 
-There are many more variables available check them out [here]((https://github.com/consul/installer/blob/1.4.1/group_vars/all))
+There are many more variables available check them out [here]((https://github.com/consul/installer/blob/1.5.0/group_vars/all))
 
 ## Other deployment options
 
@@ -290,7 +290,7 @@ If you do not have `root` access, you will need your system administrator to gra
 
 ## Using a different user than deploy
 
-Change the variable [deploy_user](https://github.com/consul/installer/blob/1.4.1/group_vars/all#L13) to the username you would like to use.
+Change the variable [deploy_user](https://github.com/consul/installer/blob/1.5.0/group_vars/all#L13) to the username you would like to use.
 
 ## Ansible Documentation
 

--- a/roles/folder_structure/tasks/main.yml
+++ b/roles/folder_structure/tasks/main.yml
@@ -22,7 +22,7 @@
         state: directory
 
     - name: Create first release
-      shell: "git archive 1.4.1 | /usr/bin/env tar -x -f - -C {{ first_release_dir }}"
+      shell: "git archive 1.5.0 | /usr/bin/env tar -x -f - -C {{ first_release_dir }}"
       args:
         chdir: "{{ consul_dir }}/repo"
 


### PR DESCRIPTION
~~:warning: Don't merge until we release CONSUL 1.5.0. When we release version 1.5.0, change the roles/folder_structure/tasks/main.yml file so it uses the 1.5.0 tag instead of the master branch.~~

## References

* Merge after we release version 1.5.0 in consul/consul#4852

## Objectives

Install the latest stable version of CONSUL.