### PR TITLE
Install PostgreSQL extensions on a shared schema

### DIFF
--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -29,11 +29,26 @@
         encrypted: yes
         priv: ALL
 
+    - name: Create the shared extensions schema
+      postgresql_schema:
+        name: shared_extensions
+        db: "{{ database_name }}"
+        owner: "{{ database_user }}"
+
     - name: Add PostgreSQL extensions
       postgresql_ext:
         name: "{{ item }}"
         db: "{{database_name}}"
+        schema: shared_extensions
       with_items:
         - plpgsql
         - unaccent
         - pg_trgm
+
+    - name: Grant usage on shared extensions schema
+      postgresql_privs:
+        db: "{{database_name}}"
+        privs: USAGE
+        type: schema
+        objs: shared_extensions
+        role: public

--- a/roles/rails/templates/database.yml
+++ b/roles/rails/templates/database.yml
@@ -3,6 +3,7 @@ default: &default
   encoding: unicode
   host: {{ database_hostname }}
   pool: 5
+  schema_search_path: "public,shared_extensions"
   username: {{ database_user}}
   password: {{ database_password }}
 


### PR DESCRIPTION
## References

* These changes are needed to make the installer compatible with multitenancy consul/consul#4030

## Objectives

* Install extensions on a shared schema so they're available to all tenants