### PR TITLE
Add missing shared public folders

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -22,6 +22,7 @@ shared_public_dirs:
   - "assets"
   - "system"
   - "ckeditor_assets"
+  - "machine_learning/data"
 
 ssh_public_key_path: "~/.ssh/id_rsa.pub"
 ansible_ssh_private_key_file: "~/.ssh/id_rsa"

--- a/group_vars/all
+++ b/group_vars/all
@@ -18,6 +18,7 @@ release_dir: "{{ consul_dir }}/current"
 shared_dirs:
   - "tmp"
   - "log"
+  - "storage"
 shared_public_dirs:
   - "assets"
   - "system"


### PR DESCRIPTION
## References

* The machine learning data folder was added to Capistrano's shared folders in consul/consul#4585
* We added this folder to Capistrano's shared folders in consul/consul@73a0a2100

## Objectives

* Make machine learning scripts work on new CONSUL installations
* Make Active Storage use a shared folder on new CONSUL installations