### PR TITLE
Update bundler arguments configuration 

### DIFF
--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -1,6 +1,18 @@
 ---
+- name: Configure Bundler path
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle config --local path {{ shared_dir }}/bundle"
+  args:
+    chdir: "{{ release_dir }}"
+    executable: /bin/bash
+
+- name: Configure Bundler environments
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle config --local without development:test"
+  args:
+    chdir: "{{ release_dir }}"
+    executable: /bin/bash
+
 - name: Install gems (this may take a few minutes)
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle install --path {{ shared_dir }}/bundle --without development test"
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bundle install"
   args:
     chdir: "{{ release_dir }}"
     executable: /bin/bash


### PR DESCRIPTION
## Background

We were getting a couple of warnings when running `bundle install --path {{ shared_dir }}/bundle --without development test`:

> [DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path '/home/deploy/consul/shared/bundle/'`, and stop using this flag
> 
> [DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set without 'development test'`, and stop using this flag

## Objectives

* Use the new way to configure the arguments given to Bundler so it keeps working in the future