### PR TITLE
Remove official support for Ubuntu 18.04

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,18 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04]
         rails_env: [staging, production]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
-        if: ${{ matrix.os != 'ubuntu-20.04' }}
-      - uses: actions/setup-python@v2
-        with:
           python-version: 3.8
-        if: ${{ matrix.os == 'ubuntu-20.04' }}
       - name: Update system packages
         run: sudo apt-get update -y
       - name: Install OpenSSH

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ It will also create a `deploy` user to install these libraries
 
 A remote server with one of the supported distributions:
 
-- Ubuntu 18.04 x64
 - Ubuntu 20.04 x64
 - Debian Buster x64
 - Debian Bullseye x64


### PR DESCRIPTION
## Objectives

* Remove support for a distribution that is no longer supported by Ubuntu or GitHub Actions

## Notes for reviewers

Tests for Debian fail, but they also fail on the master branch, so the reason why they fail isn't related to this pull request. This issue is fixed in pull request #217.