### PR TITLE
Restart DelayedJob workers after they crash

### DIFF
--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Start DelayedJobs queue
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/delayed_job -n 2 restart"
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV={{ env }} bin/delayed_job -m -n 2 restart"
   args:
     executable: /bin/bash
     chdir: "{{ release_dir }}"


### PR DESCRIPTION
## References

* We changed the way Consul runs DelayedJob processes in consul/consul#5146

## Objectives

* Use the same command to run delayed job as we use in Capistrano